### PR TITLE
[Feat]Admin Api 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,8 +36,12 @@ dependencies {
 
 	// JWT 설정
 	implementation 'io.jsonwebtoken:jjwt:0.9.1'
-	implementation "com.googlecode.json-simple:json-simple:1.1.1"                   // Google Simple JSON
-	implementation group: 'javax.xml.bind', name: 'jaxb-api', version: '2.1'		//DatatypeConverter
+
+	// Google Simple JSON
+	implementation "com.googlecode.json-simple:json-simple:1.1.1"
+
+	//DatatypeConverter
+	implementation group: 'javax.xml.bind', name: 'jaxb-api', version: '2.1'
 
 	// JPA 설정
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
@@ -54,6 +58,9 @@ dependencies {
 
 	// cool sms 설정
 	implementation 'net.nurigo:sdk:4.3.0'
+
+	// Bcrypt 설정
+	implementation 'org.mindrot:jbcrypt:0.4'
 
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'

--- a/src/main/java/com/softeer/backend/bo_domain/admin/controller/AdminLoginController.java
+++ b/src/main/java/com/softeer/backend/bo_domain/admin/controller/AdminLoginController.java
@@ -1,0 +1,37 @@
+package com.softeer.backend.bo_domain.admin.controller;
+
+import com.softeer.backend.bo_domain.admin.dto.login.AdminLoginRequestDto;
+import com.softeer.backend.bo_domain.admin.service.AdminLoginService;
+import com.softeer.backend.global.annotation.AuthInfo;
+import com.softeer.backend.global.common.dto.JwtTokenResponseDto;
+import com.softeer.backend.global.common.response.ResponseDto;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/admin")
+public class AdminLoginController {
+
+    private final AdminLoginService adminLoginService;
+
+    @PostMapping("/login")
+    ResponseDto<JwtTokenResponseDto> handleLogin(@Valid @RequestBody AdminLoginRequestDto adminLoginRequestDto) {
+        JwtTokenResponseDto jwtTokenResponseDto = adminLoginService.handleLogin(adminLoginRequestDto);
+
+        return ResponseDto.onSuccess(jwtTokenResponseDto);
+    }
+
+    @PostMapping("/logout")
+    ResponseDto<Void> handleLogout(@AuthInfo Integer adminId) {
+        adminLoginService.handleLogout(adminId);
+
+        return ResponseDto.onSuccess();
+    }
+
+
+}

--- a/src/main/java/com/softeer/backend/bo_domain/admin/controller/EventPageController.java
+++ b/src/main/java/com/softeer/backend/bo_domain/admin/controller/EventPageController.java
@@ -1,0 +1,35 @@
+package com.softeer.backend.bo_domain.admin.controller;
+
+import com.softeer.backend.bo_domain.admin.dto.event.DrawEventTimeRequestDto;
+import com.softeer.backend.bo_domain.admin.dto.event.FcfsEventTimeRequestDto;
+import com.softeer.backend.bo_domain.admin.service.EventPageService;
+import com.softeer.backend.global.common.response.ResponseDto;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/admin/event")
+public class EventPageController {
+
+    private final EventPageService eventPageService;
+
+    @PostMapping("/fcfs")
+    public ResponseDto<Void> updateFcfsEventTime(@Valid @RequestBody FcfsEventTimeRequestDto fcfsEventTimeRequestDto) {
+        eventPageService.updateFcfsEventTime(fcfsEventTimeRequestDto);
+
+        return ResponseDto.onSuccess();
+    }
+
+    @PostMapping("/draw")
+    public ResponseDto<Void> updateDrawEventTime(@Valid @RequestBody DrawEventTimeRequestDto drawEventTimeRequestDto) {
+        eventPageService.updateDrawEventTime(drawEventTimeRequestDto);
+
+        return ResponseDto.onSuccess();
+    }
+
+}

--- a/src/main/java/com/softeer/backend/bo_domain/admin/controller/IndicatorPageController.java
+++ b/src/main/java/com/softeer/backend/bo_domain/admin/controller/IndicatorPageController.java
@@ -1,0 +1,25 @@
+package com.softeer.backend.bo_domain.admin.controller;
+
+import com.softeer.backend.bo_domain.admin.dto.indicator.EventIndicatorResponseDto;
+import com.softeer.backend.bo_domain.admin.service.IndicatorPageService;
+import com.softeer.backend.fo_domain.draw.repository.DrawSettingRepository;
+import com.softeer.backend.global.common.response.ResponseDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/admin")
+public class IndicatorPageController {
+
+    private final IndicatorPageService indicatorPageService;
+
+    @GetMapping("/indicator")
+    public ResponseDto<EventIndicatorResponseDto> getEventIndicator(){
+        EventIndicatorResponseDto eventIndicatorResponseDto = indicatorPageService.getEventIndicator();
+
+        return ResponseDto.onSuccess(eventIndicatorResponseDto);
+    }
+}

--- a/src/main/java/com/softeer/backend/bo_domain/admin/controller/IndicatorPageController.java
+++ b/src/main/java/com/softeer/backend/bo_domain/admin/controller/IndicatorPageController.java
@@ -17,7 +17,7 @@ public class IndicatorPageController {
     private final IndicatorPageService indicatorPageService;
 
     @GetMapping("/indicator")
-    public ResponseDto<EventIndicatorResponseDto> getEventIndicator(){
+    public ResponseDto<EventIndicatorResponseDto> getEventIndicator() {
         EventIndicatorResponseDto eventIndicatorResponseDto = indicatorPageService.getEventIndicator();
 
         return ResponseDto.onSuccess(eventIndicatorResponseDto);

--- a/src/main/java/com/softeer/backend/bo_domain/admin/controller/MainPageController.java
+++ b/src/main/java/com/softeer/backend/bo_domain/admin/controller/MainPageController.java
@@ -1,0 +1,23 @@
+package com.softeer.backend.bo_domain.admin.controller;
+
+import com.softeer.backend.bo_domain.admin.dto.main.MainPageResponseDto;
+import com.softeer.backend.bo_domain.admin.service.MainPageService;
+import com.softeer.backend.global.common.response.ResponseDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/admin")
+public class MainPageController {
+    private final MainPageService mainPageService;
+
+    @GetMapping("/main")
+    public ResponseDto<MainPageResponseDto> getMainPage() {
+        MainPageResponseDto mainPageResponseDto = mainPageService.getMainPage();
+
+        return ResponseDto.onSuccess(mainPageResponseDto);
+    }
+}

--- a/src/main/java/com/softeer/backend/bo_domain/admin/controller/WinnerPageController.java
+++ b/src/main/java/com/softeer/backend/bo_domain/admin/controller/WinnerPageController.java
@@ -1,0 +1,52 @@
+package com.softeer.backend.bo_domain.admin.controller;
+
+import com.softeer.backend.bo_domain.admin.dto.winner.DrawWinnerListResponseDto;
+import com.softeer.backend.bo_domain.admin.dto.winner.DrawWinnerUpdateRequestDto;
+import com.softeer.backend.bo_domain.admin.dto.winner.FcfsWinnerListResponseDto;
+import com.softeer.backend.bo_domain.admin.dto.winner.FcfsWinnerUpdateRequestDto;
+import com.softeer.backend.bo_domain.admin.service.WinnerPageService;
+import com.softeer.backend.global.common.response.ResponseDto;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/admin/winner")
+public class WinnerPageController {
+    private final WinnerPageService winnerPageService;
+
+    @GetMapping("/fcfs/{round}")
+    public ResponseDto<FcfsWinnerListResponseDto> getFcfsWinnerList(@PathVariable int round) {
+
+        FcfsWinnerListResponseDto fcfsWinnerListResponseDto = winnerPageService.getFcfsWinnerList(round);
+
+        return ResponseDto.onSuccess(fcfsWinnerListResponseDto);
+    }
+
+    @GetMapping("/draw/{rank}")
+    public ResponseDto<DrawWinnerListResponseDto> getDrawWinnerList(@PathVariable int rank) {
+
+        DrawWinnerListResponseDto drawWinnerListResponseDto = winnerPageService.getDrawWinnerList(rank);
+
+        return ResponseDto.onSuccess(drawWinnerListResponseDto);
+    }
+
+    @PostMapping("/fcfs")
+    public ResponseDto<Void> updateFcfsWinnerNum(@Valid @RequestBody FcfsWinnerUpdateRequestDto fcfsWinnerUpdateRequestDto) {
+
+        winnerPageService.updateFcfsWinnerNum(fcfsWinnerUpdateRequestDto);
+
+        return ResponseDto.onSuccess();
+    }
+
+    @PostMapping("/draw")
+    public ResponseDto<Void> updateFcfsWinnerNum(@Valid @RequestBody DrawWinnerUpdateRequestDto drawWinnerUpdateRequestDto) {
+
+        winnerPageService.updateDrawWinnerNum(drawWinnerUpdateRequestDto);
+
+        return ResponseDto.onSuccess();
+    }
+
+
+}

--- a/src/main/java/com/softeer/backend/bo_domain/admin/domain/Admin.java
+++ b/src/main/java/com/softeer/backend/bo_domain/admin/domain/Admin.java
@@ -1,0 +1,28 @@
+package com.softeer.backend.bo_domain.admin.domain;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+@Builder
+@Table(name = "admin")
+public class Admin {
+
+    @Id
+    @Column(name = "admin_id")
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Integer id;
+
+    @Column(name = "admin_account", nullable = false, unique = true)
+    private String account;
+
+    @Column(name = "password", nullable = false)
+    private String password;
+
+}

--- a/src/main/java/com/softeer/backend/bo_domain/admin/dto/event/DrawEventTimeRequestDto.java
+++ b/src/main/java/com/softeer/backend/bo_domain/admin/dto/event/DrawEventTimeRequestDto.java
@@ -1,0 +1,22 @@
+package com.softeer.backend.bo_domain.admin.dto.event;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.softeer.backend.bo_domain.admin.validator.annotation.ValidDrawTimeRange;
+import lombok.*;
+
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor(access = AccessLevel.PUBLIC)
+@Builder
+@Getter
+@ValidDrawTimeRange
+public class DrawEventTimeRequestDto {
+
+    @JsonFormat(pattern = "HH:mm:ss")
+    private LocalTime startTime;
+
+    @JsonFormat(pattern = "HH:mm:ss")
+    private LocalTime endTime;
+}

--- a/src/main/java/com/softeer/backend/bo_domain/admin/dto/event/FcfsEventTimeRequestDto.java
+++ b/src/main/java/com/softeer/backend/bo_domain/admin/dto/event/FcfsEventTimeRequestDto.java
@@ -1,0 +1,29 @@
+package com.softeer.backend.bo_domain.admin.dto.event;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.softeer.backend.bo_domain.admin.validator.annotation.ValidFcfsDateRange;
+import com.softeer.backend.bo_domain.admin.validator.annotation.ValidFcfsTimeRange;
+import lombok.*;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor(access = AccessLevel.PUBLIC)
+@Builder
+@Getter
+@ValidFcfsDateRange
+@ValidFcfsTimeRange
+public class FcfsEventTimeRequestDto {
+
+    @JsonFormat(pattern = "yyyy-MM-dd")
+    private LocalDate startDate;
+
+    @JsonFormat(pattern = "yyyy-MM-dd")
+    private LocalDate endDate;
+
+    @JsonFormat(pattern = "HH:mm:ss")
+    private LocalTime startTime;
+
+}

--- a/src/main/java/com/softeer/backend/bo_domain/admin/dto/indicator/EventIndicatorResponseDto.java
+++ b/src/main/java/com/softeer/backend/bo_domain/admin/dto/indicator/EventIndicatorResponseDto.java
@@ -1,0 +1,89 @@
+package com.softeer.backend.bo_domain.admin.dto.indicator;
+
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.softeer.backend.bo_domain.admin.serializer.PercentageSerializer;
+import com.softeer.backend.bo_domain.admin.serializer.PhoneNumberSerializer;
+import com.softeer.backend.bo_domain.eventparticipation.domain.EventParticipation;
+import lombok.*;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor(access = AccessLevel.PUBLIC)
+@Builder
+@Getter
+public class EventIndicatorResponseDto {
+
+    @JsonFormat(pattern = "yyyy-MM-dd")
+    private LocalDate startDate;
+
+    @JsonFormat(pattern = "yyyy-MM-dd")
+    private LocalDate endDate;
+
+    private int totalVisitorCount;
+
+    private int totalFcfsParticipantCount;
+
+    private int totalDrawParticipantCount;
+
+    @JsonSerialize(using = PercentageSerializer.class)
+    private double fcfsParticipantRate;
+
+    @JsonSerialize(using = PercentageSerializer.class)
+    private double drawParticipantRate;
+
+    private List<VisitorNum> visitorNumList;
+
+    @Getter
+    @AllArgsConstructor
+    @Builder
+    public static class VisitorNum {
+
+        @JsonFormat(pattern = "yyyy-MM-dd")
+        private LocalDate visitDate;
+
+        private int visitorNum;
+    }
+
+    public static EventIndicatorResponseDto of(List<EventParticipation> eventParticipationList) {
+        LocalDate startDate = eventParticipationList.get(0).getEventDate();
+        LocalDate endDate = eventParticipationList.get(eventParticipationList.size() - 1).getEventDate();
+
+        int totalVisitorCount = eventParticipationList.stream()
+                .mapToInt(EventParticipation::getVisitorCount)
+                .sum();
+
+        int totalFcfsParticipantCount = eventParticipationList.stream()
+                .mapToInt(EventParticipation::getFcfsParticipantCount)
+                .sum();
+
+        int totalDrawParticipantCount = eventParticipationList.stream()
+                .mapToInt(EventParticipation::getDrawParticipantCount)
+                .sum();
+
+        double fcfsParticipantRate = (double) totalFcfsParticipantCount / (double) totalVisitorCount;
+        double drawParticipantRate = (double) totalDrawParticipantCount / (double) totalVisitorCount;
+
+        List<VisitorNum> visitorNumList = eventParticipationList.stream()
+                .map((eventParticipation) ->
+                        VisitorNum.builder()
+                                .visitDate(eventParticipation.getEventDate())
+                                .visitorNum(eventParticipation.getVisitorCount())
+                                .build())
+                .toList();
+
+        return EventIndicatorResponseDto.builder()
+                .startDate(startDate)
+                .endDate(endDate)
+                .totalVisitorCount(totalVisitorCount)
+                .totalFcfsParticipantCount(totalFcfsParticipantCount)
+                .totalDrawParticipantCount(totalDrawParticipantCount)
+                .fcfsParticipantRate(fcfsParticipantRate)
+                .drawParticipantRate(drawParticipantRate)
+                .visitorNumList(visitorNumList)
+                .build();
+    }
+}

--- a/src/main/java/com/softeer/backend/bo_domain/admin/dto/login/AdminLoginRequestDto.java
+++ b/src/main/java/com/softeer/backend/bo_domain/admin/dto/login/AdminLoginRequestDto.java
@@ -1,0 +1,20 @@
+package com.softeer.backend.bo_domain.admin.dto.login;
+
+import com.softeer.backend.global.common.constant.ValidationConstant;
+import jakarta.validation.constraints.Pattern;
+import lombok.*;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor(access = AccessLevel.PUBLIC)
+@Builder
+@Getter
+public class AdminLoginRequestDto {
+
+    @Pattern(regexp = ValidationConstant.ADMIN_ACCOUNT_REGEX,
+            message = ValidationConstant.ADMIN_ACCOUNT_MSG)
+    private String account;
+
+    @Pattern(regexp = ValidationConstant.ADMIN_PASSWORD_REGEX,
+            message = ValidationConstant.ADMIN_PASSWORD_MSG)
+    private String password;
+}

--- a/src/main/java/com/softeer/backend/bo_domain/admin/dto/main/MainPageResponseDto.java
+++ b/src/main/java/com/softeer/backend/bo_domain/admin/dto/main/MainPageResponseDto.java
@@ -1,0 +1,123 @@
+package com.softeer.backend.bo_domain.admin.dto.main;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.softeer.backend.bo_domain.admin.serializer.PercentageSerializer;
+import com.softeer.backend.fo_domain.draw.domain.DrawSetting;
+import com.softeer.backend.fo_domain.fcfs.domain.FcfsSetting;
+import lombok.*;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.Arrays;
+import java.util.List;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor(access = AccessLevel.PUBLIC)
+@Builder
+@Getter
+public class MainPageResponseDto {
+    public static final int EXPECTED_PARTICIPANT_COUNT = 10000;
+
+    private List<FcfsEvent> fcfsEventList;
+
+    private DrawEvent drawEvent;
+
+    @Getter
+    @AllArgsConstructor
+    @Builder
+    public static class FcfsEvent {
+
+        private int round;
+
+        @JsonFormat(pattern = "yyyy-MM-dd hh:mm:ss")
+        private LocalDateTime startTime;
+
+        @JsonFormat(pattern = "yyyy-MM-dd hh:mm:ss")
+        private LocalDateTime endTime;
+
+        private int winnerNum;
+    }
+
+    @Getter
+    @AllArgsConstructor
+    @Builder
+    public static class DrawEvent {
+
+        @JsonFormat(pattern = "yyyy-MM-dd")
+        private LocalDate startDate;
+
+        @JsonFormat(pattern = "yyyy-MM-dd")
+        private LocalDate endDate;
+
+        @JsonFormat(pattern = "hh:mm:ss")
+        private LocalTime startTime;
+
+        @JsonFormat(pattern = "hh:mm:ss")
+        private LocalTime endTime;
+
+        private List<DrawInfo> drawInfoList;
+    }
+
+    @Getter
+    @AllArgsConstructor
+    @Builder
+    public static class DrawInfo {
+
+        private int rank;
+
+        private int winnerNum;
+
+        @JsonSerialize(using = PercentageSerializer.class)
+        private double probability;
+    }
+
+    public static MainPageResponseDto of(List<FcfsSetting> fcfsSettingList, List<DrawSetting> drawSettingList){
+        List<FcfsEvent> fcfsEventList = fcfsSettingList.stream()
+                .map((fcfsSetting) ->
+                    FcfsEvent.builder()
+                            .round(fcfsSetting.getRound())
+                            .startTime(fcfsSetting.getStartTime())
+                            .endTime(fcfsSetting.getEndTime())
+                            .winnerNum(fcfsSetting.getWinnerNum())
+                            .build())
+                .toList();
+
+        DrawSetting drawSetting = drawSettingList.get(0);
+        DrawInfo drawInfoFirst = DrawInfo.builder()
+                .rank(1)
+                .winnerNum(drawSetting.getWinnerNum1())
+                .probability(calculateWinningProbability(drawSetting.getWinnerNum1()))
+                .build();
+        DrawInfo drawInfoSecond = DrawInfo.builder()
+                .rank(2)
+                .winnerNum(drawSetting.getWinnerNum2())
+                .probability(calculateWinningProbability(drawSetting.getWinnerNum2()))
+                .build();
+        DrawInfo drawInfoThird = DrawInfo.builder()
+                .rank(3)
+                .winnerNum(drawSetting.getWinnerNum3())
+                .probability(calculateWinningProbability(drawSetting.getWinnerNum3()))
+                .build();
+
+        List<DrawInfo> drawInfoList = Arrays.asList(drawInfoFirst, drawInfoSecond, drawInfoThird);
+        DrawEvent drawEvent = DrawEvent.builder()
+                .startDate(drawSetting.getStartDate())
+                .endDate(drawSetting.getEndDate())
+                .startTime(drawSetting.getStartTime())
+                .endTime(drawSetting.getEndTime())
+                .drawInfoList(drawInfoList)
+                .build();
+
+        return MainPageResponseDto.builder()
+                .fcfsEventList(fcfsEventList)
+                .drawEvent(drawEvent)
+                .build();
+
+    }
+
+    private static double calculateWinningProbability(int winnerNum){
+        return (double)winnerNum / (double)EXPECTED_PARTICIPANT_COUNT;
+    }
+}

--- a/src/main/java/com/softeer/backend/bo_domain/admin/dto/main/MainPageResponseDto.java
+++ b/src/main/java/com/softeer/backend/bo_domain/admin/dto/main/MainPageResponseDto.java
@@ -73,15 +73,15 @@ public class MainPageResponseDto {
         private double probability;
     }
 
-    public static MainPageResponseDto of(List<FcfsSetting> fcfsSettingList, List<DrawSetting> drawSettingList){
+    public static MainPageResponseDto of(List<FcfsSetting> fcfsSettingList, List<DrawSetting> drawSettingList) {
         List<FcfsEvent> fcfsEventList = fcfsSettingList.stream()
                 .map((fcfsSetting) ->
-                    FcfsEvent.builder()
-                            .round(fcfsSetting.getRound())
-                            .startTime(fcfsSetting.getStartTime())
-                            .endTime(fcfsSetting.getEndTime())
-                            .winnerNum(fcfsSetting.getWinnerNum())
-                            .build())
+                        FcfsEvent.builder()
+                                .round(fcfsSetting.getRound())
+                                .startTime(fcfsSetting.getStartTime())
+                                .endTime(fcfsSetting.getEndTime())
+                                .winnerNum(fcfsSetting.getWinnerNum())
+                                .build())
                 .toList();
 
         DrawSetting drawSetting = drawSettingList.get(0);
@@ -117,7 +117,7 @@ public class MainPageResponseDto {
 
     }
 
-    private static double calculateWinningProbability(int winnerNum){
-        return (double)winnerNum / (double)EXPECTED_PARTICIPANT_COUNT;
+    private static double calculateWinningProbability(int winnerNum) {
+        return (double) winnerNum / (double) EXPECTED_PARTICIPANT_COUNT;
     }
 }

--- a/src/main/java/com/softeer/backend/bo_domain/admin/dto/winner/DrawWinnerListResponseDto.java
+++ b/src/main/java/com/softeer/backend/bo_domain/admin/dto/winner/DrawWinnerListResponseDto.java
@@ -1,0 +1,48 @@
+package com.softeer.backend.bo_domain.admin.dto.winner;
+
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.softeer.backend.bo_domain.admin.serializer.PhoneNumberSerializer;
+import com.softeer.backend.fo_domain.draw.domain.Draw;
+import com.softeer.backend.fo_domain.fcfs.domain.Fcfs;
+import lombok.*;
+
+import java.util.Comparator;
+import java.util.List;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor(access = AccessLevel.PUBLIC)
+@Builder
+@Getter
+public class DrawWinnerListResponseDto {
+
+    int rank;
+
+    private List<DrawWinner> drawWinnerList;
+
+    @Getter
+    @AllArgsConstructor
+    @Builder
+    public static class DrawWinner{
+
+        private String name;
+
+        @JsonSerialize(using = PhoneNumberSerializer.class)
+        private String phoneNumber;
+    }
+
+    public static DrawWinnerListResponseDto of(List<Draw> drawList, int rank) {
+        List<DrawWinner> drawWinnerList = drawList.stream()
+                .map((draw)-> DrawWinner.builder()
+                        .name(draw.getUser().getName())
+                        .phoneNumber(draw.getUser().getPhoneNumber())
+                        .build())
+                .sorted(Comparator.comparing(DrawWinnerListResponseDto.DrawWinner::getName))
+                .toList();
+
+        return DrawWinnerListResponseDto.builder()
+                .rank(rank)
+                .drawWinnerList(drawWinnerList)
+                .build();
+    }
+
+}

--- a/src/main/java/com/softeer/backend/bo_domain/admin/dto/winner/DrawWinnerListResponseDto.java
+++ b/src/main/java/com/softeer/backend/bo_domain/admin/dto/winner/DrawWinnerListResponseDto.java
@@ -22,7 +22,7 @@ public class DrawWinnerListResponseDto {
     @Getter
     @AllArgsConstructor
     @Builder
-    public static class DrawWinner{
+    public static class DrawWinner {
 
         private String name;
 
@@ -32,7 +32,7 @@ public class DrawWinnerListResponseDto {
 
     public static DrawWinnerListResponseDto of(List<Draw> drawList, int rank) {
         List<DrawWinner> drawWinnerList = drawList.stream()
-                .map((draw)-> DrawWinner.builder()
+                .map((draw) -> DrawWinner.builder()
                         .name(draw.getUser().getName())
                         .phoneNumber(draw.getUser().getPhoneNumber())
                         .build())

--- a/src/main/java/com/softeer/backend/bo_domain/admin/dto/winner/DrawWinnerUpdateRequestDto.java
+++ b/src/main/java/com/softeer/backend/bo_domain/admin/dto/winner/DrawWinnerUpdateRequestDto.java
@@ -1,0 +1,16 @@
+package com.softeer.backend.bo_domain.admin.dto.winner;
+
+import lombok.*;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor(access = AccessLevel.PUBLIC)
+@Builder
+@Getter
+public class DrawWinnerUpdateRequestDto {
+
+    private int firstWinnerNum;
+
+    private int secondWinnerNum;
+
+    private int thirdWinnerNum;
+}

--- a/src/main/java/com/softeer/backend/bo_domain/admin/dto/winner/FcfsWinnerListResponseDto.java
+++ b/src/main/java/com/softeer/backend/bo_domain/admin/dto/winner/FcfsWinnerListResponseDto.java
@@ -1,0 +1,47 @@
+package com.softeer.backend.bo_domain.admin.dto.winner;
+
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.softeer.backend.bo_domain.admin.serializer.PhoneNumberSerializer;
+import com.softeer.backend.fo_domain.fcfs.domain.Fcfs;
+import lombok.*;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor(access = AccessLevel.PUBLIC)
+@Builder
+@Getter
+public class FcfsWinnerListResponseDto {
+
+    int round;
+
+    private List<FcfsWinner> fcfsWinnerList;
+
+    @Getter
+    @AllArgsConstructor
+    @Builder
+    public static class FcfsWinner{
+
+        private String name;
+
+        @JsonSerialize(using = PhoneNumberSerializer.class)
+        private String phoneNumber;
+    }
+
+    public static FcfsWinnerListResponseDto of(List<Fcfs> fcfsList, int round) {
+        List<FcfsWinner> fcfsWinnerList = fcfsList.stream()
+                .map((fcfs)-> FcfsWinner.builder()
+                        .name(fcfs.getUser().getName())
+                        .phoneNumber(fcfs.getUser().getPhoneNumber())
+                        .build())
+                .sorted(Comparator.comparing(FcfsWinner::getName))
+                .toList();
+
+        return FcfsWinnerListResponseDto.builder()
+                .round(round)
+                .fcfsWinnerList(fcfsWinnerList)
+                .build();
+    }
+}

--- a/src/main/java/com/softeer/backend/bo_domain/admin/dto/winner/FcfsWinnerListResponseDto.java
+++ b/src/main/java/com/softeer/backend/bo_domain/admin/dto/winner/FcfsWinnerListResponseDto.java
@@ -22,7 +22,7 @@ public class FcfsWinnerListResponseDto {
     @Getter
     @AllArgsConstructor
     @Builder
-    public static class FcfsWinner{
+    public static class FcfsWinner {
 
         private String name;
 
@@ -32,7 +32,7 @@ public class FcfsWinnerListResponseDto {
 
     public static FcfsWinnerListResponseDto of(List<Fcfs> fcfsList, int round) {
         List<FcfsWinner> fcfsWinnerList = fcfsList.stream()
-                .map((fcfs)-> FcfsWinner.builder()
+                .map((fcfs) -> FcfsWinner.builder()
                         .name(fcfs.getUser().getName())
                         .phoneNumber(fcfs.getUser().getPhoneNumber())
                         .build())

--- a/src/main/java/com/softeer/backend/bo_domain/admin/dto/winner/FcfsWinnerUpdateRequestDto.java
+++ b/src/main/java/com/softeer/backend/bo_domain/admin/dto/winner/FcfsWinnerUpdateRequestDto.java
@@ -1,0 +1,14 @@
+package com.softeer.backend.bo_domain.admin.dto.winner;
+
+import lombok.*;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor(access = AccessLevel.PUBLIC)
+@Builder
+@Getter
+public class FcfsWinnerUpdateRequestDto {
+
+    private int round;
+
+    private int fcfsWinnerNum;
+}

--- a/src/main/java/com/softeer/backend/bo_domain/admin/exception/AdminException.java
+++ b/src/main/java/com/softeer/backend/bo_domain/admin/exception/AdminException.java
@@ -1,0 +1,11 @@
+package com.softeer.backend.bo_domain.admin.exception;
+
+import com.softeer.backend.global.common.code.BaseErrorCode;
+import com.softeer.backend.global.common.exception.GeneralException;
+
+public class AdminException extends GeneralException {
+
+    public AdminException(BaseErrorCode code) {
+        super(code);
+    }
+}

--- a/src/main/java/com/softeer/backend/bo_domain/admin/repository/AdminRepository.java
+++ b/src/main/java/com/softeer/backend/bo_domain/admin/repository/AdminRepository.java
@@ -1,0 +1,12 @@
+package com.softeer.backend.bo_domain.admin.repository;
+
+import com.softeer.backend.bo_domain.admin.domain.Admin;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface AdminRepository extends JpaRepository<Admin, Integer> {
+    Optional<Admin> findByAccount(String account);
+}

--- a/src/main/java/com/softeer/backend/bo_domain/admin/serializer/PercentageSerializer.java
+++ b/src/main/java/com/softeer/backend/bo_domain/admin/serializer/PercentageSerializer.java
@@ -1,0 +1,19 @@
+package com.softeer.backend.bo_domain.admin.serializer;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.SerializerProvider;
+
+import java.io.IOException;
+
+public class PercentageSerializer extends JsonSerializer<Double> {
+
+    @Override
+    public void serialize(Double value, JsonGenerator gen, SerializerProvider serializers) throws IOException {
+        if (value != null) {
+            // 백분율로 변환하고 % 기호를 붙입니다.
+            String formatted = String.format("%.2f%%", value * 100);
+            gen.writeString(formatted);
+        }
+    }
+}

--- a/src/main/java/com/softeer/backend/bo_domain/admin/serializer/PhoneNumberSerializer.java
+++ b/src/main/java/com/softeer/backend/bo_domain/admin/serializer/PhoneNumberSerializer.java
@@ -1,0 +1,17 @@
+package com.softeer.backend.bo_domain.admin.serializer;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.SerializerProvider;
+
+import java.io.IOException;
+
+public class PhoneNumberSerializer extends JsonSerializer<String> {
+
+    @Override
+    public void serialize(String value, JsonGenerator gen, SerializerProvider serializers) throws IOException {
+
+        String formatted = value.replaceAll("(\\d{3})(\\d{3})(\\d+)", "$1-$2-$3");
+        gen.writeString(formatted);
+    }
+}

--- a/src/main/java/com/softeer/backend/bo_domain/admin/service/AdminLoginService.java
+++ b/src/main/java/com/softeer/backend/bo_domain/admin/service/AdminLoginService.java
@@ -1,0 +1,57 @@
+package com.softeer.backend.bo_domain.admin.service;
+
+import com.softeer.backend.bo_domain.admin.domain.Admin;
+import com.softeer.backend.bo_domain.admin.dto.login.AdminLoginRequestDto;
+import com.softeer.backend.bo_domain.admin.exception.AdminException;
+import com.softeer.backend.bo_domain.admin.repository.AdminRepository;
+import com.softeer.backend.bo_domain.admin.util.PasswordEncoder;
+import com.softeer.backend.global.common.code.status.ErrorStatus;
+import com.softeer.backend.global.common.constant.RoleType;
+import com.softeer.backend.global.common.dto.JwtClaimsDto;
+import com.softeer.backend.global.common.dto.JwtTokenResponseDto;
+import com.softeer.backend.global.util.JwtUtil;
+import com.softeer.backend.global.util.StringRedisUtil;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class AdminLoginService {
+
+    private final AdminRepository adminRepository;
+    private final JwtUtil jwtUtil;
+    private final StringRedisUtil stringRedisUtil;
+    private final PasswordEncoder passwordEncoder;
+
+    @Transactional(readOnly = true)
+    public JwtTokenResponseDto handleLogin(AdminLoginRequestDto adminLoginRequestDto){
+
+        Admin admin = adminRepository.findByAccount(adminLoginRequestDto.getAccount())
+                .orElseThrow(()->{
+                    log.error("Admin not found.");
+                    return new AdminException(ErrorStatus._NOT_FOUND);
+                });
+
+        if(!passwordEncoder.matches(adminLoginRequestDto.getPassword(), admin.getPassword())){
+            log.error("Admin password not match.");
+            throw new AdminException(ErrorStatus._NOT_FOUND);
+        }
+
+        return jwtUtil.createServiceToken(JwtClaimsDto.builder()
+                .id(admin.getId())
+                .roleType(RoleType.ROLE_ADMIN)
+                .build());
+
+    }
+
+    public void handleLogout(int adminId){
+
+        stringRedisUtil.deleteRefreshToken(JwtClaimsDto.builder()
+                .id(adminId)
+                .roleType(RoleType.ROLE_ADMIN)
+                .build());
+    }
+}

--- a/src/main/java/com/softeer/backend/bo_domain/admin/service/AdminLoginService.java
+++ b/src/main/java/com/softeer/backend/bo_domain/admin/service/AdminLoginService.java
@@ -27,15 +27,15 @@ public class AdminLoginService {
     private final PasswordEncoder passwordEncoder;
 
     @Transactional(readOnly = true)
-    public JwtTokenResponseDto handleLogin(AdminLoginRequestDto adminLoginRequestDto){
+    public JwtTokenResponseDto handleLogin(AdminLoginRequestDto adminLoginRequestDto) {
 
         Admin admin = adminRepository.findByAccount(adminLoginRequestDto.getAccount())
-                .orElseThrow(()->{
+                .orElseThrow(() -> {
                     log.error("Admin not found.");
                     return new AdminException(ErrorStatus._NOT_FOUND);
                 });
 
-        if(!passwordEncoder.matches(adminLoginRequestDto.getPassword(), admin.getPassword())){
+        if (!passwordEncoder.matches(adminLoginRequestDto.getPassword(), admin.getPassword())) {
             log.error("Admin password not match.");
             throw new AdminException(ErrorStatus._NOT_FOUND);
         }
@@ -47,7 +47,7 @@ public class AdminLoginService {
 
     }
 
-    public void handleLogout(int adminId){
+    public void handleLogout(int adminId) {
 
         stringRedisUtil.deleteRefreshToken(JwtClaimsDto.builder()
                 .id(adminId)

--- a/src/main/java/com/softeer/backend/bo_domain/admin/service/EventPageService.java
+++ b/src/main/java/com/softeer/backend/bo_domain/admin/service/EventPageService.java
@@ -1,0 +1,78 @@
+package com.softeer.backend.bo_domain.admin.service;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.softeer.backend.bo_domain.admin.dto.event.DrawEventTimeRequestDto;
+import com.softeer.backend.bo_domain.admin.dto.event.FcfsEventTimeRequestDto;
+import com.softeer.backend.fo_domain.draw.domain.DrawSetting;
+import com.softeer.backend.fo_domain.draw.repository.DrawSettingRepository;
+import com.softeer.backend.fo_domain.fcfs.domain.FcfsSetting;
+import com.softeer.backend.fo_domain.fcfs.repository.FcfsSettingRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.temporal.TemporalAdjusters;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class EventPageService {
+
+    private FcfsSettingRepository fcfsSettingRepository;
+
+    private DrawSettingRepository drawSettingRepository;
+
+    public void updateFcfsEventTime(FcfsEventTimeRequestDto fcfsEventTimeRequestDto){
+
+        List<FcfsSetting> fcfsSettingList = fcfsSettingRepository.findAll(Sort.by(Sort.Order.asc("id")));
+
+        LocalDate startDate = fcfsEventTimeRequestDto.getStartDate();
+        LocalDate endDate = fcfsEventTimeRequestDto.getEndDate();
+        LocalTime startTime = fcfsEventTimeRequestDto.getStartTime();
+
+        updateFcfsSetting(fcfsSettingList.get(0), startDate, startTime);
+        updateFcfsSetting(fcfsSettingList.get(1), endDate, startTime);
+
+        LocalDate nextWeekStartDate = startDate.plusWeeks(1);
+        LocalDate nextWeekEndDate = endDate.plusWeeks(1);
+
+        updateFcfsSetting(fcfsSettingList.get(2), nextWeekStartDate, startTime);
+        updateFcfsSetting(fcfsSettingList.get(3), nextWeekEndDate, startTime);
+
+        DrawSetting drawSetting = drawSettingRepository.findAll().get(0);
+        updateDrawSetting(drawSetting, startDate, endDate);
+
+    }
+
+    private void updateFcfsSetting(FcfsSetting setting, LocalDate date, LocalTime time) {
+
+        LocalDateTime newStartTime = LocalDateTime.of(date, time);
+        LocalDateTime newEndTime = newStartTime.plusHours(2);
+
+        setting.setStartTime(newStartTime);
+        setting.setEndTime(newEndTime);
+    }
+
+    private void updateDrawSetting(DrawSetting drawSetting, LocalDate startDate, LocalDate endDate) {
+        LocalDate startDateOfDraw = startDate.with(TemporalAdjusters.previousOrSame(DayOfWeek.SUNDAY));
+
+        LocalDate endDateOfPreviousWeek = endDate.with(TemporalAdjusters.nextOrSame(DayOfWeek.SATURDAY));
+        LocalDate endDateOfDraw = endDateOfPreviousWeek.with(TemporalAdjusters.next(DayOfWeek.SATURDAY));
+
+        drawSetting.setStartDate(startDateOfDraw);
+        drawSetting.setEndDate(endDateOfDraw);
+    }
+
+    public void updateDrawEventTime(DrawEventTimeRequestDto drawEventTimeRequestDto){
+        DrawSetting drawSetting = drawSettingRepository.findAll().get(0);
+
+        drawSetting.setStartTime(drawEventTimeRequestDto.getStartTime());
+        drawSetting.setEndTime(drawEventTimeRequestDto.getEndTime());
+    }
+}

--- a/src/main/java/com/softeer/backend/bo_domain/admin/service/EventPageService.java
+++ b/src/main/java/com/softeer/backend/bo_domain/admin/service/EventPageService.java
@@ -28,7 +28,7 @@ public class EventPageService {
 
     private DrawSettingRepository drawSettingRepository;
 
-    public void updateFcfsEventTime(FcfsEventTimeRequestDto fcfsEventTimeRequestDto){
+    public void updateFcfsEventTime(FcfsEventTimeRequestDto fcfsEventTimeRequestDto) {
 
         List<FcfsSetting> fcfsSettingList = fcfsSettingRepository.findAll(Sort.by(Sort.Order.asc("id")));
 
@@ -69,7 +69,7 @@ public class EventPageService {
         drawSetting.setEndDate(endDateOfDraw);
     }
 
-    public void updateDrawEventTime(DrawEventTimeRequestDto drawEventTimeRequestDto){
+    public void updateDrawEventTime(DrawEventTimeRequestDto drawEventTimeRequestDto) {
         DrawSetting drawSetting = drawSettingRepository.findAll().get(0);
 
         drawSetting.setStartTime(drawEventTimeRequestDto.getStartTime());

--- a/src/main/java/com/softeer/backend/bo_domain/admin/service/IndicatorPageService.java
+++ b/src/main/java/com/softeer/backend/bo_domain/admin/service/IndicatorPageService.java
@@ -18,7 +18,7 @@ public class IndicatorPageService {
     private final EventParticipationRepository eventParticipationRepository;
     private final DrawSettingRepository drawSettingRepository;
 
-    public EventIndicatorResponseDto getEventIndicator(){
+    public EventIndicatorResponseDto getEventIndicator() {
 
         DrawSetting drawSetting = drawSettingRepository.findAll().get(0);
 

--- a/src/main/java/com/softeer/backend/bo_domain/admin/service/IndicatorPageService.java
+++ b/src/main/java/com/softeer/backend/bo_domain/admin/service/IndicatorPageService.java
@@ -1,0 +1,32 @@
+package com.softeer.backend.bo_domain.admin.service;
+
+import com.softeer.backend.bo_domain.admin.dto.indicator.EventIndicatorResponseDto;
+import com.softeer.backend.bo_domain.eventparticipation.domain.EventParticipation;
+import com.softeer.backend.bo_domain.eventparticipation.repository.EventParticipationRepository;
+import com.softeer.backend.fo_domain.draw.domain.DrawSetting;
+import com.softeer.backend.fo_domain.draw.repository.DrawSettingRepository;
+import kotlinx.serialization.Required;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class IndicatorPageService {
+
+    private final EventParticipationRepository eventParticipationRepository;
+    private final DrawSettingRepository drawSettingRepository;
+
+    public EventIndicatorResponseDto getEventIndicator(){
+
+        DrawSetting drawSetting = drawSettingRepository.findAll().get(0);
+
+        List<EventParticipation> eventParticipationList = eventParticipationRepository.findAllByEventDateBetween(
+                drawSetting.getStartDate(), drawSetting.getEndDate()
+        );
+
+        return EventIndicatorResponseDto.of(eventParticipationList);
+    }
+
+}

--- a/src/main/java/com/softeer/backend/bo_domain/admin/service/MainPageService.java
+++ b/src/main/java/com/softeer/backend/bo_domain/admin/service/MainPageService.java
@@ -1,0 +1,29 @@
+package com.softeer.backend.bo_domain.admin.service;
+
+import com.softeer.backend.bo_domain.admin.dto.main.MainPageResponseDto;
+import com.softeer.backend.fo_domain.draw.domain.DrawSetting;
+import com.softeer.backend.fo_domain.draw.repository.DrawSettingRepository;
+import com.softeer.backend.fo_domain.fcfs.domain.FcfsSetting;
+import com.softeer.backend.fo_domain.fcfs.repository.FcfsSettingRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class MainPageService {
+
+    private final FcfsSettingRepository fcfsSettingRepository;
+    private final DrawSettingRepository drawSettingRepository;
+
+    @Transactional(readOnly = true)
+    public MainPageResponseDto getMainPage(){
+        List<FcfsSetting> fcfsSettingList = fcfsSettingRepository.findAll(Sort.by(Sort.Order.asc("round")));
+        List<DrawSetting> drawSetting = drawSettingRepository.findAll();
+
+        return MainPageResponseDto.of(fcfsSettingList, drawSetting);
+    }
+}

--- a/src/main/java/com/softeer/backend/bo_domain/admin/service/MainPageService.java
+++ b/src/main/java/com/softeer/backend/bo_domain/admin/service/MainPageService.java
@@ -20,7 +20,7 @@ public class MainPageService {
     private final DrawSettingRepository drawSettingRepository;
 
     @Transactional(readOnly = true)
-    public MainPageResponseDto getMainPage(){
+    public MainPageResponseDto getMainPage() {
         List<FcfsSetting> fcfsSettingList = fcfsSettingRepository.findAll(Sort.by(Sort.Order.asc("round")));
         List<DrawSetting> drawSetting = drawSettingRepository.findAll();
 

--- a/src/main/java/com/softeer/backend/bo_domain/admin/service/WinnerPageService.java
+++ b/src/main/java/com/softeer/backend/bo_domain/admin/service/WinnerPageService.java
@@ -1,0 +1,69 @@
+package com.softeer.backend.bo_domain.admin.service;
+
+import com.softeer.backend.bo_domain.admin.dto.winner.DrawWinnerListResponseDto;
+import com.softeer.backend.bo_domain.admin.dto.winner.DrawWinnerUpdateRequestDto;
+import com.softeer.backend.bo_domain.admin.dto.winner.FcfsWinnerListResponseDto;
+import com.softeer.backend.bo_domain.admin.dto.winner.FcfsWinnerUpdateRequestDto;
+import com.softeer.backend.bo_domain.admin.exception.AdminException;
+import com.softeer.backend.fo_domain.draw.domain.Draw;
+import com.softeer.backend.fo_domain.draw.domain.DrawSetting;
+import com.softeer.backend.fo_domain.draw.repository.DrawRepository;
+import com.softeer.backend.fo_domain.draw.repository.DrawSettingRepository;
+import com.softeer.backend.fo_domain.fcfs.domain.Fcfs;
+import com.softeer.backend.fo_domain.fcfs.domain.FcfsSetting;
+import com.softeer.backend.fo_domain.fcfs.repository.FcfsRepository;
+import com.softeer.backend.fo_domain.fcfs.repository.FcfsSettingRepository;
+import com.softeer.backend.fo_domain.user.repository.UserRepository;
+import com.softeer.backend.global.common.code.status.ErrorStatus;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class WinnerPageService {
+
+    private final FcfsRepository fcfsRepository;
+    private final DrawRepository drawRepository;
+    private final FcfsSettingRepository fcfsSettingRepository;
+    private final DrawSettingRepository drawSettingRepository;
+
+
+    @Transactional(readOnly = true)
+    public FcfsWinnerListResponseDto getFcfsWinnerList(int round){
+        List<Fcfs> fcfsList = fcfsRepository.findFcfsWithUser(round);
+
+        return FcfsWinnerListResponseDto.of(fcfsList, round);
+    }
+
+    @Transactional(readOnly = true)
+    public DrawWinnerListResponseDto getDrawWinnerList(int rank){
+        List<Draw> drawList = drawRepository.findDrawWithUser(rank);
+
+        return DrawWinnerListResponseDto.of(drawList, rank);
+    }
+
+    @Transactional
+    public void updateFcfsWinnerNum(FcfsWinnerUpdateRequestDto fcfsWinnerUpdateRequestDto){
+        FcfsSetting fcfsSetting = fcfsSettingRepository.findByRound(fcfsWinnerUpdateRequestDto.getRound())
+                .orElseThrow(() -> {
+                    log.error("fcfsSetting not found");
+                    return new AdminException(ErrorStatus._NOT_FOUND);
+                });
+
+        fcfsSetting.setWinnerNum(fcfsWinnerUpdateRequestDto.getFcfsWinnerNum());
+    }
+
+    @Transactional
+    public void updateDrawWinnerNum(DrawWinnerUpdateRequestDto drawWinnerUpdateRequestDto){
+        DrawSetting drawSetting = drawSettingRepository.findAll().get(0);
+
+        drawSetting.setWinnerNum1(drawWinnerUpdateRequestDto.getFirstWinnerNum());
+        drawSetting.setWinnerNum2(drawWinnerUpdateRequestDto.getSecondWinnerNum());
+        drawSetting.setWinnerNum3(drawWinnerUpdateRequestDto.getThirdWinnerNum());
+    }
+}

--- a/src/main/java/com/softeer/backend/bo_domain/admin/service/WinnerPageService.java
+++ b/src/main/java/com/softeer/backend/bo_domain/admin/service/WinnerPageService.java
@@ -34,21 +34,21 @@ public class WinnerPageService {
 
 
     @Transactional(readOnly = true)
-    public FcfsWinnerListResponseDto getFcfsWinnerList(int round){
+    public FcfsWinnerListResponseDto getFcfsWinnerList(int round) {
         List<Fcfs> fcfsList = fcfsRepository.findFcfsWithUser(round);
 
         return FcfsWinnerListResponseDto.of(fcfsList, round);
     }
 
     @Transactional(readOnly = true)
-    public DrawWinnerListResponseDto getDrawWinnerList(int rank){
+    public DrawWinnerListResponseDto getDrawWinnerList(int rank) {
         List<Draw> drawList = drawRepository.findDrawWithUser(rank);
 
         return DrawWinnerListResponseDto.of(drawList, rank);
     }
 
     @Transactional
-    public void updateFcfsWinnerNum(FcfsWinnerUpdateRequestDto fcfsWinnerUpdateRequestDto){
+    public void updateFcfsWinnerNum(FcfsWinnerUpdateRequestDto fcfsWinnerUpdateRequestDto) {
         FcfsSetting fcfsSetting = fcfsSettingRepository.findByRound(fcfsWinnerUpdateRequestDto.getRound())
                 .orElseThrow(() -> {
                     log.error("fcfsSetting not found");
@@ -59,7 +59,7 @@ public class WinnerPageService {
     }
 
     @Transactional
-    public void updateDrawWinnerNum(DrawWinnerUpdateRequestDto drawWinnerUpdateRequestDto){
+    public void updateDrawWinnerNum(DrawWinnerUpdateRequestDto drawWinnerUpdateRequestDto) {
         DrawSetting drawSetting = drawSettingRepository.findAll().get(0);
 
         drawSetting.setWinnerNum1(drawWinnerUpdateRequestDto.getFirstWinnerNum());

--- a/src/main/java/com/softeer/backend/bo_domain/admin/util/PasswordEncoder.java
+++ b/src/main/java/com/softeer/backend/bo_domain/admin/util/PasswordEncoder.java
@@ -1,0 +1,18 @@
+package com.softeer.backend.bo_domain.admin.util;
+
+import org.mindrot.jbcrypt.BCrypt;
+import org.springframework.stereotype.Component;
+
+@Component
+public class PasswordEncoder {
+
+    // 비밀번호를 해시화
+    public String encode(String rawPassword) {
+        return BCrypt.hashpw(rawPassword, BCrypt.gensalt());
+    }
+
+    // 비밀번호 비교 (평문 vs 해시)
+    public boolean matches(String rawPassword, String encodedPassword) {
+        return BCrypt.checkpw(rawPassword, encodedPassword);
+    }
+}

--- a/src/main/java/com/softeer/backend/bo_domain/admin/validator/DrawTimeRangeValidator.java
+++ b/src/main/java/com/softeer/backend/bo_domain/admin/validator/DrawTimeRangeValidator.java
@@ -1,0 +1,39 @@
+package com.softeer.backend.bo_domain.admin.validator;
+
+import com.softeer.backend.bo_domain.admin.dto.event.DrawEventTimeRequestDto;
+import com.softeer.backend.bo_domain.admin.validator.annotation.ValidDrawTimeRange;
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+
+import java.time.LocalTime;
+
+public class DrawTimeRangeValidator implements ConstraintValidator<ValidDrawTimeRange, DrawEventTimeRequestDto> {
+
+    @Override
+    public void initialize(ValidDrawTimeRange constraintAnnotation) {
+        ConstraintValidator.super.initialize(constraintAnnotation);
+    }
+
+    @Override
+    public boolean isValid(DrawEventTimeRequestDto value, ConstraintValidatorContext context) {
+        if (value.getStartTime() == null || value.getEndTime() == null) {
+            return true;
+        }
+
+        LocalTime startTime = value.getStartTime();
+        LocalTime endTime = value.getEndTime();
+
+        // 시작 시간 검증: 09:00:00 이후
+        if (startTime.isBefore(LocalTime.of(9, 0))) {
+            return false;
+        }
+
+        // 종료 시간 검증: 23:59:59 이전
+        if (endTime.isAfter(LocalTime.of(23, 59, 59))) {
+            return false;
+        }
+
+        // 시작 시간이 종료 시간보다 이전인지 확인
+        return !startTime.isAfter(endTime);
+    }
+}

--- a/src/main/java/com/softeer/backend/bo_domain/admin/validator/FcfsDateRangeValidator.java
+++ b/src/main/java/com/softeer/backend/bo_domain/admin/validator/FcfsDateRangeValidator.java
@@ -1,0 +1,41 @@
+package com.softeer.backend.bo_domain.admin.validator;
+
+import com.softeer.backend.bo_domain.admin.dto.event.FcfsEventTimeRequestDto;
+import com.softeer.backend.bo_domain.admin.validator.annotation.ValidFcfsDateRange;
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.time.temporal.TemporalAdjusters;
+import java.time.temporal.WeekFields;
+import java.util.Locale;
+
+public class FcfsDateRangeValidator implements ConstraintValidator<ValidFcfsDateRange, FcfsEventTimeRequestDto> {
+
+    @Override
+    public void initialize(ValidFcfsDateRange constraintAnnotation) {
+        ConstraintValidator.super.initialize(constraintAnnotation);
+    }
+
+    @Override
+    public boolean isValid(FcfsEventTimeRequestDto value, ConstraintValidatorContext context) {
+        if (value.getStartDate() == null || value.getEndDate() == null) {
+            return true;
+        }
+
+        LocalDate startDate = value.getStartDate();
+        LocalDate endDate = value.getEndDate();
+
+        LocalDate startDateWeekStart = startDate.with(TemporalAdjusters.previousOrSame(DayOfWeek.SUNDAY));
+        LocalDate endDateWeekStart = endDate.with(TemporalAdjusters.previousOrSame(DayOfWeek.SUNDAY));
+
+        boolean isSameWeek = startDateWeekStart.equals(endDateWeekStart);
+
+        // 시작 날짜가 종료 날짜보다 이전인지 확인
+        boolean isStartBeforeEnd = !startDate.isAfter(endDate);
+
+        // 두 검증 조건을 모두 만족하는지 확인
+        return isSameWeek && isStartBeforeEnd;
+    }
+}

--- a/src/main/java/com/softeer/backend/bo_domain/admin/validator/FcfsTimeRangeValidator.java
+++ b/src/main/java/com/softeer/backend/bo_domain/admin/validator/FcfsTimeRangeValidator.java
@@ -1,0 +1,34 @@
+package com.softeer.backend.bo_domain.admin.validator;
+
+import com.softeer.backend.bo_domain.admin.dto.event.FcfsEventTimeRequestDto;
+import com.softeer.backend.bo_domain.admin.validator.annotation.ValidFcfsTimeRange;
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+
+import java.time.LocalTime;
+
+public class FcfsTimeRangeValidator implements ConstraintValidator<ValidFcfsTimeRange, FcfsEventTimeRequestDto> {
+
+    @Override
+    public void initialize(ValidFcfsTimeRange constraintAnnotation) {
+        ConstraintValidator.super.initialize(constraintAnnotation);
+    }
+
+    @Override
+    public boolean isValid(FcfsEventTimeRequestDto value, ConstraintValidatorContext context) {
+        if (value.getStartTime() == null) {
+            return true;
+        }
+
+        LocalTime startTime = value.getStartTime();
+
+        // 시작 시간이 오전 9시 이후인지 검증
+        boolean isStartTimeValid = !startTime.isBefore(LocalTime.of(9, 0));
+
+        // 시작 시간이 오후 6시 이전인지 검증
+        boolean isEndTimeValid = !startTime.isAfter(LocalTime.of(18, 0));
+
+        // 모든 검증 조건이 만족되는지 확인
+        return isStartTimeValid && isEndTimeValid;
+    }
+}

--- a/src/main/java/com/softeer/backend/bo_domain/admin/validator/annotation/ValidDrawTimeRange.java
+++ b/src/main/java/com/softeer/backend/bo_domain/admin/validator/annotation/ValidDrawTimeRange.java
@@ -11,10 +11,12 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 @Constraint(validatedBy = DrawTimeRangeValidator.class)
-@Target({ ElementType.TYPE })
+@Target({ElementType.TYPE})
 @Retention(RetentionPolicy.RUNTIME)
 public @interface ValidDrawTimeRange {
     String message() default "시작시간은 09:00 이후, 종료 시간은 11:59:59 이전이어야 합니다.";
+
     Class<?>[] groups() default {};
+
     Class<? extends Payload>[] payload() default {};
 }

--- a/src/main/java/com/softeer/backend/bo_domain/admin/validator/annotation/ValidDrawTimeRange.java
+++ b/src/main/java/com/softeer/backend/bo_domain/admin/validator/annotation/ValidDrawTimeRange.java
@@ -1,0 +1,20 @@
+package com.softeer.backend.bo_domain.admin.validator.annotation;
+
+import com.softeer.backend.bo_domain.admin.validator.DrawTimeRangeValidator;
+import com.softeer.backend.bo_domain.admin.validator.FcfsDateRangeValidator;
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Constraint(validatedBy = DrawTimeRangeValidator.class)
+@Target({ ElementType.TYPE })
+@Retention(RetentionPolicy.RUNTIME)
+public @interface ValidDrawTimeRange {
+    String message() default "시작시간은 09:00 이후, 종료 시간은 11:59:59 이전이어야 합니다.";
+    Class<?>[] groups() default {};
+    Class<? extends Payload>[] payload() default {};
+}

--- a/src/main/java/com/softeer/backend/bo_domain/admin/validator/annotation/ValidFcfsDateRange.java
+++ b/src/main/java/com/softeer/backend/bo_domain/admin/validator/annotation/ValidFcfsDateRange.java
@@ -10,10 +10,12 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 @Constraint(validatedBy = FcfsDateRangeValidator.class)
-@Target({ ElementType.TYPE })
+@Target({ElementType.TYPE})
 @Retention(RetentionPolicy.RUNTIME)
 public @interface ValidFcfsDateRange {
     String message() default "선착순 날짜는 같은 주에 있어야 합니다.";
+
     Class<?>[] groups() default {};
+
     Class<? extends Payload>[] payload() default {};
 }

--- a/src/main/java/com/softeer/backend/bo_domain/admin/validator/annotation/ValidFcfsDateRange.java
+++ b/src/main/java/com/softeer/backend/bo_domain/admin/validator/annotation/ValidFcfsDateRange.java
@@ -1,0 +1,19 @@
+package com.softeer.backend.bo_domain.admin.validator.annotation;
+
+import com.softeer.backend.bo_domain.admin.validator.FcfsDateRangeValidator;
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Constraint(validatedBy = FcfsDateRangeValidator.class)
+@Target({ ElementType.TYPE })
+@Retention(RetentionPolicy.RUNTIME)
+public @interface ValidFcfsDateRange {
+    String message() default "선착순 날짜는 같은 주에 있어야 합니다.";
+    Class<?>[] groups() default {};
+    Class<? extends Payload>[] payload() default {};
+}

--- a/src/main/java/com/softeer/backend/bo_domain/admin/validator/annotation/ValidFcfsTimeRange.java
+++ b/src/main/java/com/softeer/backend/bo_domain/admin/validator/annotation/ValidFcfsTimeRange.java
@@ -10,10 +10,12 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 @Constraint(validatedBy = FcfsTimeRangeValidator.class)
-@Target({ ElementType.TYPE })
+@Target({ElementType.TYPE})
 @Retention(RetentionPolicy.RUNTIME)
 public @interface ValidFcfsTimeRange {
     String message() default "시작 시간값은 09:00:00 ~ 18:00:00 범위에 속해야 합니다.";
+
     Class<?>[] groups() default {};
+
     Class<? extends Payload>[] payload() default {};
 }

--- a/src/main/java/com/softeer/backend/bo_domain/admin/validator/annotation/ValidFcfsTimeRange.java
+++ b/src/main/java/com/softeer/backend/bo_domain/admin/validator/annotation/ValidFcfsTimeRange.java
@@ -1,0 +1,19 @@
+package com.softeer.backend.bo_domain.admin.validator.annotation;
+
+import com.softeer.backend.bo_domain.admin.validator.FcfsTimeRangeValidator;
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Constraint(validatedBy = FcfsTimeRangeValidator.class)
+@Target({ ElementType.TYPE })
+@Retention(RetentionPolicy.RUNTIME)
+public @interface ValidFcfsTimeRange {
+    String message() default "시작 시간값은 09:00:00 ~ 18:00:00 범위에 속해야 합니다.";
+    Class<?>[] groups() default {};
+    Class<? extends Payload>[] payload() default {};
+}

--- a/src/main/java/com/softeer/backend/bo_domain/eventparticipation/domain/EventParticipation.java
+++ b/src/main/java/com/softeer/backend/bo_domain/eventparticipation/domain/EventParticipation.java
@@ -3,6 +3,8 @@ package com.softeer.backend.bo_domain.eventparticipation.domain;
 import jakarta.persistence.*;
 import lombok.*;
 
+import java.time.LocalDate;
+
 @Entity
 @NoArgsConstructor
 @AllArgsConstructor
@@ -18,7 +20,7 @@ public class EventParticipation {
 
     @Column(name = "total_visitors_count", nullable = false)
     @Builder.Default
-    private int totalVisitorsCount = 0;
+    private int visitorCount = 0;
 
     @Column(name = "fcfs_participant_count", nullable = false)
     @Builder.Default
@@ -28,8 +30,11 @@ public class EventParticipation {
     @Builder.Default
     private int drawParticipantCount = 0;
 
+    @Column(name = "event_date", nullable = false)
+    private LocalDate eventDate;
+
     public void addTotalVisitorsCount(int totalVisitorsCount) {
-        this.totalVisitorsCount += totalVisitorsCount;
+        this.visitorCount += totalVisitorsCount;
     }
 
     public void addFcfsParticipantCount(int fcfsParticipantCount) {

--- a/src/main/java/com/softeer/backend/bo_domain/eventparticipation/repository/EventParticipationRepository.java
+++ b/src/main/java/com/softeer/backend/bo_domain/eventparticipation/repository/EventParticipationRepository.java
@@ -3,10 +3,16 @@ package com.softeer.backend.bo_domain.eventparticipation.repository;
 import com.softeer.backend.bo_domain.eventparticipation.domain.EventParticipation;
 import org.springframework.dao.EmptyResultDataAccessException;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
+import java.time.LocalDate;
 import java.util.List;
 
 public interface EventParticipationRepository extends JpaRepository<EventParticipation, Integer> {
+
+    @Query("SELECT e FROM EventParticipation e WHERE e.eventDate BETWEEN :startDate AND :endDate")
+    List<EventParticipation> findAllByEventDateBetween(@Param("startDate") LocalDate startDate, @Param("endDate") LocalDate endDate);
 
     default EventParticipation findSingleEventParticipation() {
         List<EventParticipation> results = findAll();

--- a/src/main/java/com/softeer/backend/fo_domain/comment/service/CommentService.java
+++ b/src/main/java/com/softeer/backend/fo_domain/comment/service/CommentService.java
@@ -10,6 +10,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
@@ -25,6 +26,7 @@ public class CommentService {
      * <p>
      * 커서 기반 무한 스크롤 기능을 사용하여 다음 cursor 값을 받아 해당 값보다 작으면서 정해진 개수 만큼의 기대평을 반환한다.
      */
+    @Transactional(readOnly = true)
     public CommentsResponseDto getComments(Integer userId, Integer cursor) {
 
         PageRequest pageRequest = PageRequest.of(0, SCROLL_SIZE + 1);
@@ -38,6 +40,7 @@ public class CommentService {
     /**
      * 기대평을 저장하는 메서드
      */
+    @Transactional
     public void saveComment(Integer userId, int commentNum) {
 
         // 로그인 한 유저가 기대평을 등록했다면 User entity의 id값을 기반으로 닉네임을 설정한다.

--- a/src/main/java/com/softeer/backend/fo_domain/draw/domain/Draw.java
+++ b/src/main/java/com/softeer/backend/fo_domain/draw/domain/Draw.java
@@ -8,6 +8,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.sql.Date;
+import java.time.LocalDateTime;
 
 @Getter
 @Entity
@@ -29,5 +30,5 @@ public class Draw {
     private Integer rank;
 
     @Column(name = "winning_date")
-    private Date winningDate;
+    private LocalDateTime winningDate;
 }

--- a/src/main/java/com/softeer/backend/fo_domain/draw/domain/DrawSetting.java
+++ b/src/main/java/com/softeer/backend/fo_domain/draw/domain/DrawSetting.java
@@ -3,12 +3,17 @@ package com.softeer.backend.fo_domain.draw.domain;
 import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
+import lombok.Setter;
 import org.springframework.format.annotation.DateTimeFormat;
 
 import java.sql.Date;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
 
 @Entity
 @Getter
+@Setter
 @Table(name = "draw_setting")
 @RequiredArgsConstructor
 public class DrawSetting {
@@ -17,13 +22,17 @@ public class DrawSetting {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Integer draw_setting_id;
 
+    @Column(name = "start_date")
+    private LocalDate startDate;
+
+    @Column(name = "end_date")
+    private LocalDate endDate;
+
     @Column(name = "start_time")
-    @DateTimeFormat(pattern = "yyyy-MM-dd HH:mm:ss")
-    private Date startTime;
+    private LocalTime startTime;
 
     @Column(name = "end_time")
-    @DateTimeFormat(pattern = "yyyy-MM-dd HH:mm:ss")
-    private Date endTime;
+    private LocalTime endTime;
 
     @Column(name = "winner_num_1")
     private Integer winnerNum1;

--- a/src/main/java/com/softeer/backend/fo_domain/draw/repository/DrawRepository.java
+++ b/src/main/java/com/softeer/backend/fo_domain/draw/repository/DrawRepository.java
@@ -2,8 +2,15 @@ package com.softeer.backend.fo_domain.draw.repository;
 
 import com.softeer.backend.fo_domain.draw.domain.Draw;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+
+import java.util.List;
 
 @Repository
 public interface DrawRepository extends JpaRepository<Draw, Integer> {
+
+    @Query("SELECT d FROM Draw d JOIN FETCH d.user WHERE d.rank = :rank")
+    List<Draw> findDrawWithUser(@Param("rank") int rank);
 }

--- a/src/main/java/com/softeer/backend/fo_domain/draw/service/DrawSettingManager.java
+++ b/src/main/java/com/softeer/backend/fo_domain/draw/service/DrawSettingManager.java
@@ -9,11 +9,15 @@ import com.softeer.backend.global.util.EventLockRedisUtil;
 import jakarta.annotation.PostConstruct;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
+import net.bytebuddy.asm.Advice;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
 import org.springframework.scheduling.support.CronTrigger;
 import org.springframework.stereotype.Component;
 
 import java.sql.Date;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
 
 @Getter
 @Component
@@ -23,8 +27,10 @@ public class DrawSettingManager {
     private final ThreadPoolTaskScheduler taskScheduler;
     private final EventLockRedisUtil eventLockRedisUtil;
 
-    private Date startTime;
-    private Date endTime;
+    private LocalDate startDate;
+    private LocalDate endDate;
+    private LocalTime startTime;
+    private LocalTime endTime;
     private int winnerNum1;
     private int winnerNum2;
     private int winnerNum3;
@@ -37,6 +43,8 @@ public class DrawSettingManager {
         DrawSetting drawSetting = drawSettingRepository.findById(1)
                 .orElseThrow(() -> new DrawException(ErrorStatus._NOT_FOUND));
 
+        startDate = drawSetting.getStartDate();
+        endDate = drawSetting.getEndDate();
         startTime = drawSetting.getStartTime();
         endTime = drawSetting.getEndTime();
         winnerNum1 = drawSetting.getWinnerNum1();

--- a/src/main/java/com/softeer/backend/fo_domain/fcfs/domain/FcfsSetting.java
+++ b/src/main/java/com/softeer/backend/fo_domain/fcfs/domain/FcfsSetting.java
@@ -1,10 +1,7 @@
 package com.softeer.backend.fo_domain.fcfs.domain;
 
 import jakarta.persistence.*;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 import java.time.LocalDateTime;
 
@@ -12,6 +9,7 @@ import java.time.LocalDateTime;
 @NoArgsConstructor
 @AllArgsConstructor
 @Getter
+@Setter
 @Builder
 @Table(name = "fcfs_setting")
 public class FcfsSetting {

--- a/src/main/java/com/softeer/backend/fo_domain/fcfs/repository/FcfsRepository.java
+++ b/src/main/java/com/softeer/backend/fo_domain/fcfs/repository/FcfsRepository.java
@@ -2,9 +2,16 @@ package com.softeer.backend.fo_domain.fcfs.repository;
 
 import com.softeer.backend.fo_domain.fcfs.domain.Fcfs;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+
+import java.util.List;
 
 @Repository
 public interface FcfsRepository extends JpaRepository<Fcfs, Integer> {
+
+    @Query("SELECT f FROM Fcfs f JOIN FETCH f.user WHERE f.round = :round")
+    List<Fcfs> findFcfsWithUser(@Param("round") int round);
 
 }

--- a/src/main/java/com/softeer/backend/fo_domain/fcfs/service/FcfsSettingManager.java
+++ b/src/main/java/com/softeer/backend/fo_domain/fcfs/service/FcfsSettingManager.java
@@ -96,6 +96,7 @@ public class FcfsSettingManager {
 
                 log.info("FcfsSetting updated to round {}", round);
 
+                // TODO: 현재 날짜를 기준으로 하루 전 날짜로 방문자수, 추첨 및 선착순 참가자 수를 EventParticipation에 저장하는 로직 구현
                 int participantCount = eventLockRedisUtil.getData(RedisLockPrefix.FCFS_LOCK_PREFIX.getPrefix() + round);
                 EventParticipation eventParticipation = eventParticipationRepository.findSingleEventParticipation();
                 eventParticipation.addFcfsParticipantCount(participantCount);

--- a/src/main/java/com/softeer/backend/fo_domain/user/controller/LoginController.java
+++ b/src/main/java/com/softeer/backend/fo_domain/user/controller/LoginController.java
@@ -1,7 +1,7 @@
 package com.softeer.backend.fo_domain.user.controller;
 
 import com.softeer.backend.fo_domain.user.dto.LoginRequestDto;
-import com.softeer.backend.fo_domain.user.dto.UserTokenResponseDto;
+import com.softeer.backend.global.common.dto.JwtTokenResponseDto;
 import com.softeer.backend.fo_domain.user.service.LoginService;
 import com.softeer.backend.global.common.response.ResponseDto;
 import jakarta.validation.Valid;
@@ -17,10 +17,10 @@ public class LoginController {
     private final LoginService loginService;
 
     @PostMapping("/login")
-    ResponseDto<UserTokenResponseDto> handleLogin(@Valid @RequestBody LoginRequestDto loginRequestDto) {
-        UserTokenResponseDto userTokenResponseDto = loginService.handleLogin(loginRequestDto);
+    ResponseDto<JwtTokenResponseDto> handleLogin(@Valid @RequestBody LoginRequestDto loginRequestDto) {
+        JwtTokenResponseDto jwtTokenResponseDto = loginService.handleLogin(loginRequestDto);
 
-        return ResponseDto.onSuccess(userTokenResponseDto);
+        return ResponseDto.onSuccess(jwtTokenResponseDto);
     }
 
 }

--- a/src/main/java/com/softeer/backend/fo_domain/user/service/LoginService.java
+++ b/src/main/java/com/softeer/backend/fo_domain/user/service/LoginService.java
@@ -2,12 +2,12 @@ package com.softeer.backend.fo_domain.user.service;
 
 import com.softeer.backend.fo_domain.user.domain.User;
 import com.softeer.backend.fo_domain.user.dto.LoginRequestDto;
-import com.softeer.backend.fo_domain.user.dto.UserTokenResponseDto;
+import com.softeer.backend.global.common.dto.JwtTokenResponseDto;
 import com.softeer.backend.fo_domain.user.exception.UserException;
 import com.softeer.backend.fo_domain.user.repository.UserRepository;
 import com.softeer.backend.global.common.code.status.ErrorStatus;
 import com.softeer.backend.global.common.constant.RoleType;
-import com.softeer.backend.global.common.entity.JwtClaimsDto;
+import com.softeer.backend.global.common.dto.JwtClaimsDto;
 import com.softeer.backend.global.util.JwtUtil;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -28,8 +28,8 @@ public class LoginService {
      * 3. 전화번호가 이미 User DB에 등록되어 있는 경우, 전화번호로 User 객체를 조회한다.
      * 4. User 객체의 id를 얻은 후에, access & refresh token을 client에게 전달한다.
      */
-    @Transactional
-    public UserTokenResponseDto handleLogin(LoginRequestDto loginRequestDto) {
+    @Transactional(readOnly = true)
+    public JwtTokenResponseDto handleLogin(LoginRequestDto loginRequestDto) {
 
         // 인증번호가 인증 되지 않은 경우, 예외 발생
         if (!loginRequestDto.getHasCodeVerified()) {

--- a/src/main/java/com/softeer/backend/global/annotation/argumentresolver/AuthInfoArgumentResolver.java
+++ b/src/main/java/com/softeer/backend/global/annotation/argumentresolver/AuthInfoArgumentResolver.java
@@ -1,7 +1,7 @@
 package com.softeer.backend.global.annotation.argumentresolver;
 
 import com.softeer.backend.global.annotation.AuthInfo;
-import com.softeer.backend.global.common.entity.JwtClaimsDto;
+import com.softeer.backend.global.common.dto.JwtClaimsDto;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.NonNull;
 import org.springframework.core.MethodParameter;

--- a/src/main/java/com/softeer/backend/global/common/code/status/SuccessStatus.java
+++ b/src/main/java/com/softeer/backend/global/common/code/status/SuccessStatus.java
@@ -13,7 +13,7 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor
 public enum SuccessStatus implements BaseCode {
     // Success
-    _OK(HttpStatus.OK, "S-200", "요청 처리 성공");
+    _OK(HttpStatus.OK, "S200", "요청 처리 성공");
 
     // 예외의 Http 상태값
     private final HttpStatus httpStatus;

--- a/src/main/java/com/softeer/backend/global/common/constant/ValidationConstant.java
+++ b/src/main/java/com/softeer/backend/global/common/constant/ValidationConstant.java
@@ -9,4 +9,15 @@ public class ValidationConstant {
     public static final String VERIFICATION_CODE_REGEX = "^[a-zA-Z0-9]{6}$";
     public static final String VERIFICATION_CODE_MSG = "잘못된 인증코드 형식입니다.";
 
+    // 최소 4자에서 최대 20자까지 허용
+    // 영어 대문자, 소문자, 숫자 허용
+    public static final String ADMIN_ACCOUNT_REGEX = "^[a-zA-Z0-9]{4,20}$";
+    public static final String ADMIN_ACCOUNT_MSG = "잘못된 아이디 형식입니다.";
+
+    // 최소 8자에서 최대 20자까지 허용
+    // 적어도 하나의 대문자, 소문자, 숫자, 특수문자 포함
+    // 허용할 특수문자: @, #, $, %, &, *, !, ^
+    public static final String ADMIN_PASSWORD_REGEX = "^(?=.*[a-z])(?=.*[A-Z])(?=.*\\d)(?=.*[@#$%^&*!])[A-Za-z\\d@#$%^&*!]{8,20}$";
+    public static final String ADMIN_PASSWORD_MSG = "잘못된 비밀번호 형식입니다.";
+
 }

--- a/src/main/java/com/softeer/backend/global/common/dto/JwtClaimsDto.java
+++ b/src/main/java/com/softeer/backend/global/common/dto/JwtClaimsDto.java
@@ -1,4 +1,4 @@
-package com.softeer.backend.global.common.entity;
+package com.softeer.backend.global.common.dto;
 
 import com.softeer.backend.global.common.constant.RoleType;
 import lombok.Builder;

--- a/src/main/java/com/softeer/backend/global/common/dto/JwtTokenResponseDto.java
+++ b/src/main/java/com/softeer/backend/global/common/dto/JwtTokenResponseDto.java
@@ -1,4 +1,4 @@
-package com.softeer.backend.fo_domain.user.dto;
+package com.softeer.backend.global.common.dto;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
 import lombok.AllArgsConstructor;
@@ -12,7 +12,7 @@ import java.time.LocalDateTime;
 @Setter
 @Builder
 @AllArgsConstructor
-public class UserTokenResponseDto {
+public class JwtTokenResponseDto {
 
     private String accessToken;
 

--- a/src/main/java/com/softeer/backend/global/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/softeer/backend/global/filter/JwtAuthenticationFilter.java
@@ -3,13 +3,13 @@ package com.softeer.backend.global.filter;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import com.softeer.backend.global.common.code.status.ErrorStatus;
-import com.softeer.backend.global.common.entity.JwtClaimsDto;
+import com.softeer.backend.global.common.dto.JwtClaimsDto;
 import com.softeer.backend.global.common.exception.JwtAuthenticationException;
 import com.softeer.backend.global.common.response.ResponseDto;
 import com.softeer.backend.global.config.properties.JwtProperties;
 import com.softeer.backend.global.util.JwtUtil;
 import com.softeer.backend.global.util.StringRedisUtil;
-import com.softeer.backend.fo_domain.user.dto.UserTokenResponseDto;
+import com.softeer.backend.global.common.dto.JwtTokenResponseDto;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
@@ -172,23 +172,23 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
                                                        String refreshToken) throws IOException {
         LocalDateTime expireTime = LocalDateTime.now().plusSeconds(this.jwtProperties.getAccessExpiration() / 1000);
         // refresh token, access token 을 응답 본문에 넣어 응답
-        UserTokenResponseDto userTokenResponseDto = UserTokenResponseDto.builder()
+        JwtTokenResponseDto jwtTokenResponseDto = JwtTokenResponseDto.builder()
                 .accessToken(accessToken)
                 .refreshToken(refreshToken)
                 .expiredTime(expireTime)
                 .build();
-        makeResultResponse(response, userTokenResponseDto);
+        makeResultResponse(response, jwtTokenResponseDto);
     }
 
     private void makeResultResponse(HttpServletResponse response,
-                                    UserTokenResponseDto userTokenResponseDto) throws IOException {
+                                    JwtTokenResponseDto jwtTokenResponseDto) throws IOException {
         response.setStatus(HttpStatus.OK.value());
         response.setContentType("application/json");
         response.setCharacterEncoding("UTF-8");
 
         try (OutputStream os = response.getOutputStream()) {
             ObjectMapper objectMapper = new ObjectMapper().registerModule(new JavaTimeModule());
-            ResponseDto<UserTokenResponseDto> responseDto = ResponseDto.onSuccess(userTokenResponseDto);
+            ResponseDto<JwtTokenResponseDto> responseDto = ResponseDto.onSuccess(jwtTokenResponseDto);
             objectMapper.writeValue(os, responseDto);
             os.flush();
         }

--- a/src/main/java/com/softeer/backend/global/filter/JwtAuthorizationFilter.java
+++ b/src/main/java/com/softeer/backend/global/filter/JwtAuthorizationFilter.java
@@ -2,7 +2,7 @@ package com.softeer.backend.global.filter;
 
 import com.softeer.backend.global.common.code.status.ErrorStatus;
 import com.softeer.backend.global.common.constant.RoleType;
-import com.softeer.backend.global.common.entity.JwtClaimsDto;
+import com.softeer.backend.global.common.dto.JwtClaimsDto;
 import com.softeer.backend.global.common.exception.JwtAuthorizationException;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;

--- a/src/main/java/com/softeer/backend/global/util/JwtUtil.java
+++ b/src/main/java/com/softeer/backend/global/util/JwtUtil.java
@@ -2,10 +2,10 @@ package com.softeer.backend.global.util;
 
 import com.softeer.backend.global.common.code.status.ErrorStatus;
 import com.softeer.backend.global.common.constant.RoleType;
-import com.softeer.backend.global.common.entity.JwtClaimsDto;
+import com.softeer.backend.global.common.dto.JwtClaimsDto;
 import com.softeer.backend.global.common.exception.JwtAuthenticationException;
 import com.softeer.backend.global.config.properties.JwtProperties;
-import com.softeer.backend.fo_domain.user.dto.UserTokenResponseDto;
+import com.softeer.backend.global.common.dto.JwtTokenResponseDto;
 import io.jsonwebtoken.*;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
@@ -89,13 +89,13 @@ public class JwtUtil {
     }
 
     // 전화번호 로그인 및 admin 로그인 시 jwt 응답 생성 + redis refresh 저장
-    public UserTokenResponseDto createServiceToken(JwtClaimsDto jwtClaimsDto) {
+    public JwtTokenResponseDto createServiceToken(JwtClaimsDto jwtClaimsDto) {
         stringRedisUtil.deleteData(stringRedisUtil.getRedisKeyForJwt(jwtClaimsDto));
         String accessToken = createAccessToken(jwtClaimsDto);
         String refreshToken = createRefreshToken(jwtClaimsDto);
 
         // 서비스 토큰 생성
-        UserTokenResponseDto userTokenResponseDto = UserTokenResponseDto.builder()
+        JwtTokenResponseDto jwtTokenResponseDto = JwtTokenResponseDto.builder()
                 .accessToken(accessToken)
                 .refreshToken(refreshToken)
                 .expiredTime(LocalDateTime.now().plusSeconds(jwtProperties.getAccessExpiration() / 1000))
@@ -103,9 +103,9 @@ public class JwtUtil {
 
         // redis refresh token 저장
         stringRedisUtil.setDataExpire(stringRedisUtil.getRedisKeyForJwt(jwtClaimsDto),
-                userTokenResponseDto.getRefreshToken(), jwtProperties.getRefreshExpiration());
+                jwtTokenResponseDto.getRefreshToken(), jwtProperties.getRefreshExpiration());
 
-        return userTokenResponseDto;
+        return jwtTokenResponseDto;
     }
 
     // token 유효성 검증

--- a/src/main/java/com/softeer/backend/global/util/StringRedisUtil.java
+++ b/src/main/java/com/softeer/backend/global/util/StringRedisUtil.java
@@ -1,7 +1,7 @@
 package com.softeer.backend.global.util;
 
 import com.softeer.backend.global.common.constant.RoleType;
-import com.softeer.backend.global.common.entity.JwtClaimsDto;
+import com.softeer.backend.global.common.dto.JwtClaimsDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.data.redis.core.ValueOperations;
@@ -81,6 +81,12 @@ public class StringRedisUtil {
         RoleType roleType = jwtClaimsDto.getRoleType();
 
         return roleType.getRedisKeyPrefix() + id;
+    }
+
+    // redis에 저장된 Refresh Token을 삭제하는 메서드
+    public void deleteRefreshToken(JwtClaimsDto jwtClaimsDto) {
+
+        deleteData(getRedisKeyForJwt(jwtClaimsDto));
     }
 
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,8 +1,0 @@
-
-jwt:
-  bearer: ${JWT_BEARER:Bearer}
-  secret: ${JWT_SECRET_KEY}
-  access-expiration: ${JWT_ACCESS_EXPIRE:3600000} # 1?? (??: ms)
-  access-header: ${JWT_ACCESS_HEADER:Authorization} # Access Token ??
-  refresh-expiration: ${JWT_REFRESH_EXPIRE:86400000} # 1? (??: ms)
-  refresh-header: ${JWT_REFRESH_HEADER:Authorization-Refresh} # Refresh Token ??

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,0 +1,8 @@
+
+jwt:
+  bearer: ${JWT_BEARER:Bearer}
+  secret: ${JWT_SECRET_KEY}
+  access-expiration: ${JWT_ACCESS_EXPIRE:3600000} # 1?? (??: ms)
+  access-header: ${JWT_ACCESS_HEADER:Authorization} # Access Token ??
+  refresh-expiration: ${JWT_REFRESH_EXPIRE:86400000} # 1? (??: ms)
+  refresh-header: ${JWT_REFRESH_HEADER:Authorization-Refresh} # Refresh Token ??


### PR DESCRIPTION
## 요약

Admin Api 구현

## 작업 내용

- notion에 정리한 admin api 모두 구현하기
- event_participation 테이블에 event_date 컬럼 추가하여 시간별로 데이터 관리하도록 변경
- draw_time 테이블에서 start_time, end_time을 추가

## 관련 이슈
<!--  관련된 이슈를 적어주세요.  -->

close #62 

## 첨부 자료 (선택사항)
