### PR TITLE
[Feat] 댓글 조회시 댓글 순서를 반대로 보내기

### DIFF
--- a/src/main/java/com/softeer/backend/fo_domain/comment/repository/CommentRepository.java
+++ b/src/main/java/com/softeer/backend/fo_domain/comment/repository/CommentRepository.java
@@ -9,5 +9,5 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface CommentRepository extends JpaRepository<Comment, Integer> {
 
-    Page<Comment> findAllByIdLessThanOrderByIdDesc(Integer id, Pageable pageable);
+    Page<Comment> findAllByIdLessThanOrderById(Integer id, Pageable pageable);
 }

--- a/src/main/java/com/softeer/backend/fo_domain/comment/service/CommentService.java
+++ b/src/main/java/com/softeer/backend/fo_domain/comment/service/CommentService.java
@@ -29,7 +29,7 @@ public class CommentService {
     public CommentsResponseDto getComments(Integer userId, Integer cursor) {
 
         PageRequest pageRequest = PageRequest.of(0, SCROLL_SIZE + 1);
-        Page<Comment> page = commentRepository.findAllByIdLessThanOrderByIdDesc(cursor, pageRequest);
+        Page<Comment> page = commentRepository.findAllByIdLessThanOrderById(cursor, pageRequest);
         List<Comment> comments = page.getContent();
 
         ScrollPaginationUtil<Comment> commentCursor = ScrollPaginationUtil.of(comments, SCROLL_SIZE);

--- a/src/main/java/com/softeer/backend/fo_domain/mainpage/dto/MainPageEventResponseDto.java
+++ b/src/main/java/com/softeer/backend/fo_domain/mainpage/dto/MainPageEventResponseDto.java
@@ -14,6 +14,10 @@ public class MainPageEventResponseDto {
 
     private String endDate;
 
+    private String eventTitle;
+
+    private String eventDescription;
+
     private String fcfsInfo;
 
     private String totalDrawWinner;

--- a/src/main/java/com/softeer/backend/fo_domain/mainpage/service/MainPageService.java
+++ b/src/main/java/com/softeer/backend/fo_domain/mainpage/service/MainPageService.java
@@ -40,6 +40,8 @@ public class MainPageService {
         return MainPageEventResponseDto.builder()
                 .startDate(drawSetting.getStartDate().format(eventTimeFormatter))
                 .endDate(drawSetting.getEndDate().format(eventTimeFormatter))
+                .eventTitle(staticResourcesUtil.getData("EVENT_TITLE"))
+                .eventDescription(staticResourcesUtil.getData("EVENT_DESCRIPTION"))
                 .fcfsInfo(staticResourcesUtil.getData("FCFS_INFO"))
                 .totalDrawWinner(staticResourcesUtil.getData("TOTAL_DRAW_WINNER"))
                 .remainDrawCount(staticResourcesUtil.getData("REMAIN_DRAW_COUNT"))

--- a/src/main/java/com/softeer/backend/global/staticresources/constant/StaticText.java
+++ b/src/main/java/com/softeer/backend/global/staticresources/constant/StaticText.java
@@ -4,6 +4,10 @@ import lombok.Getter;
 
 @Getter
 public enum StaticText {
+    EVENT_TITLE("신차 출시 기념 EVENT"),
+    EVENT_DESCRIPTION("현대자동차의 The new IONIQ 5 출시 기념 이벤트로 여러분을 초대합니다.\n" +
+            "24시간 무료 렌트, 신차 할인 쿠폰 및 다양한 경품을 받아보세요."),
+
     FCFS_INFO("매주 %s, %s %s시 선착순 %s명"),
     FCFS_TITLE("'24시 내 차' 이벤트"),
     FCFS_CONTENT("하단의 The new IONIQ 5 정보를 바탕으로 빠르게 문장 퀴즈를 맞춰\n" +

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,8 +1,0 @@
-
-jwt:
-  bearer: ${JWT_BEARER:Bearer}
-  secret: ${JWT_SECRET_KEY}
-  access-expiration: ${JWT_ACCESS_EXPIRE:3600000} # 1?? (??: ms)
-  access-header: ${JWT_ACCESS_HEADER:Authorization} # Access Token ??
-  refresh-expiration: ${JWT_REFRESH_EXPIRE:86400000} # 1? (??: ms)
-  refresh-header: ${JWT_REFRESH_HEADER:Authorization-Refresh} # Refresh Token ??

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,0 +1,8 @@
+
+jwt:
+  bearer: ${JWT_BEARER:Bearer}
+  secret: ${JWT_SECRET_KEY}
+  access-expiration: ${JWT_ACCESS_EXPIRE:3600000} # 1?? (??: ms)
+  access-header: ${JWT_ACCESS_HEADER:Authorization} # Access Token ??
+  refresh-expiration: ${JWT_REFRESH_EXPIRE:86400000} # 1? (??: ms)
+  refresh-header: ${JWT_REFRESH_HEADER:Authorization-Refresh} # Refresh Token ??


### PR DESCRIPTION
## 요약

댓글 조회시 댓글 순서를 반대로 보내기

## 작업 내용

- 댓글 조회시 댓글 순서를 오래된 댓글부터 보내도록 수정
- 메인 페이지의 이벤트 정적 정보를 응답할 때 eventTitle, eventDescription 정보 추가

## 관련 이슈
<!--  관련된 이슈를 적어주세요.  -->

close #95 

## 첨부 자료 (선택사항)
