### PR TITLE
[Feat] 메인페이지 방문자 수 관리하는 기능 구현

### DIFF
--- a/src/main/java/com/softeer/backend/fo_domain/draw/service/DrawService.java
+++ b/src/main/java/com/softeer/backend/fo_domain/draw/service/DrawService.java
@@ -11,7 +11,7 @@ import com.softeer.backend.fo_domain.share.exception.ShareUrlInfoException;
 import com.softeer.backend.fo_domain.share.repository.ShareInfoRepository;
 import com.softeer.backend.fo_domain.share.repository.ShareUrlInfoRepository;
 import com.softeer.backend.global.common.code.status.ErrorStatus;
-import com.softeer.backend.global.common.constant.RedisLockPrefix;
+import com.softeer.backend.global.common.constant.RedisKeyPrefix;
 import com.softeer.backend.global.common.response.ResponseDto;
 import com.softeer.backend.global.util.EventLockRedisUtil;
 import lombok.RequiredArgsConstructor;
@@ -163,7 +163,7 @@ public class DrawService {
      * @param userId  사용자 아이디
      */
     private void saveWinnerInfo(int ranking, int userId) {
-        String drawTempKey = RedisLockPrefix.DRAW_TEMP_PREFIX.getPrefix() + ranking;
+        String drawTempKey = RedisKeyPrefix.DRAW_TEMP_PREFIX.getPrefix() + ranking;
         eventLockRedisUtil.addValueToSet(drawTempKey, userId);
     }
 
@@ -175,7 +175,7 @@ public class DrawService {
     private int getRankingIfWinner(int userId) {
         String drawTempKey;
         for (int ranking = 1; ranking < 4; ranking++) {
-            drawTempKey = RedisLockPrefix.DRAW_TEMP_PREFIX.getPrefix() + ranking;
+            drawTempKey = RedisKeyPrefix.DRAW_TEMP_PREFIX.getPrefix() + ranking;
             Set<Integer> drawTempSet = eventLockRedisUtil.getAllDataAsSet(drawTempKey);
             if (drawTempSet.contains(userId)) {
                 return ranking;

--- a/src/main/java/com/softeer/backend/fo_domain/draw/service/DrawSettingManager.java
+++ b/src/main/java/com/softeer/backend/fo_domain/draw/service/DrawSettingManager.java
@@ -4,19 +4,16 @@ import com.softeer.backend.fo_domain.draw.domain.DrawSetting;
 import com.softeer.backend.fo_domain.draw.exception.DrawException;
 import com.softeer.backend.fo_domain.draw.repository.DrawSettingRepository;
 import com.softeer.backend.global.common.code.status.ErrorStatus;
-import com.softeer.backend.global.common.constant.RedisLockPrefix;
+import com.softeer.backend.global.common.constant.RedisKeyPrefix;
 import com.softeer.backend.global.util.EventLockRedisUtil;
 import jakarta.annotation.PostConstruct;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
-import net.bytebuddy.asm.Advice;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
 import org.springframework.scheduling.support.CronTrigger;
 import org.springframework.stereotype.Component;
 
-import java.sql.Date;
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 import java.time.LocalTime;
 
 @Getter
@@ -58,7 +55,7 @@ public class DrawSettingManager {
     private void deleteTempWinnerSetFromRedis() {
         String drawTempKey;
         for (int ranking = 1; ranking < 4; ranking++) {
-            drawTempKey = RedisLockPrefix.DRAW_TEMP_PREFIX.getPrefix() + ranking;
+            drawTempKey = RedisKeyPrefix.DRAW_TEMP_PREFIX.getPrefix() + ranking;
             eventLockRedisUtil.deleteTempWinnerList(drawTempKey);
         }
     }

--- a/src/main/java/com/softeer/backend/fo_domain/fcfs/service/FcfsService.java
+++ b/src/main/java/com/softeer/backend/fo_domain/fcfs/service/FcfsService.java
@@ -1,22 +1,13 @@
 package com.softeer.backend.fo_domain.fcfs.service;
 
-import com.softeer.backend.fo_domain.fcfs.domain.Fcfs;
 import com.softeer.backend.fo_domain.fcfs.dto.FcfsFailResponseDtoDto;
-import com.softeer.backend.fo_domain.fcfs.dto.FcfsResponseDto;
-import com.softeer.backend.fo_domain.fcfs.dto.FcfsSuccessResponseDto;
 import com.softeer.backend.fo_domain.fcfs.repository.FcfsRepository;
-import com.softeer.backend.fo_domain.user.domain.User;
-import com.softeer.backend.fo_domain.user.exception.UserException;
 import com.softeer.backend.fo_domain.user.repository.UserRepository;
-import com.softeer.backend.global.annotation.EventLock;
-import com.softeer.backend.global.common.code.status.ErrorStatus;
-import com.softeer.backend.global.common.constant.RedisLockPrefix;
+import com.softeer.backend.global.common.constant.RedisKeyPrefix;
 import com.softeer.backend.global.util.EventLockRedisUtil;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
-
-import java.util.Set;
 
 /**
  * 선착순 관련 이벤트를 처리하는 클래스
@@ -78,7 +69,7 @@ public class FcfsService {
 //    }
 
     private FcfsFailResponseDtoDto countFcfsParticipant(int round) {
-        eventLockRedisUtil.incrementParticipantCount(RedisLockPrefix.FCFS_PARTICIPANT_COUNT_PREFIX.getPrefix() + round);
+        eventLockRedisUtil.incrementData(RedisKeyPrefix.FCFS_PARTICIPANT_COUNT_PREFIX.getPrefix() + round);
 
         return new FcfsFailResponseDtoDto(1);
     }

--- a/src/main/java/com/softeer/backend/fo_domain/fcfs/service/FcfsSettingManager.java
+++ b/src/main/java/com/softeer/backend/fo_domain/fcfs/service/FcfsSettingManager.java
@@ -1,21 +1,17 @@
 package com.softeer.backend.fo_domain.fcfs.service;
 
-import com.softeer.backend.bo_domain.eventparticipation.domain.EventParticipation;
 import com.softeer.backend.bo_domain.eventparticipation.repository.EventParticipationRepository;
 import com.softeer.backend.fo_domain.fcfs.domain.FcfsSetting;
 import com.softeer.backend.fo_domain.fcfs.dto.FcfsSettingDto;
 import com.softeer.backend.fo_domain.fcfs.repository.FcfsSettingRepository;
-import com.softeer.backend.global.common.constant.RedisLockPrefix;
 import com.softeer.backend.global.util.EventLockRedisUtil;
 import jakarta.annotation.PostConstruct;
-import jakarta.transaction.Transactional;
 import lombok.*;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
-import org.springframework.scheduling.support.CronTrigger;
 import org.springframework.stereotype.Component;
 
-import java.time.LocalDateTime;
+import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.ScheduledFuture;
@@ -32,23 +28,21 @@ public class FcfsSettingManager {
     private List<FcfsSettingDto> fcfsSettingList;
 
     @Setter
-    private boolean isFcfsClosed;
+    private boolean isFcfsClosed = false;
 
     private final FcfsSettingRepository fcfsSettingRepository;
     private final ThreadPoolTaskScheduler taskScheduler;
     private final EventLockRedisUtil eventLockRedisUtil;
     private final EventParticipationRepository eventParticipationRepository;
 
-    private ScheduledFuture<?> scheduledFuture;
 
     @PostConstruct
     public void init() {
         loadInitialData();
-//        scheduleTask();
     }
 
-    public FcfsSettingDto getFcfsSettingByRound(int round){
-        return fcfsSettingList.get(round-1);
+    public FcfsSettingDto getFcfsSettingByRound(int round) {
+        return fcfsSettingList.get(round - 1);
     }
 
     /**
@@ -64,7 +58,7 @@ public class FcfsSettingManager {
         }
 
         fcfsSettings.forEach((fcfsSetting) -> {
-            fcfsSettingList.set(fcfsSetting.getRound()-1, FcfsSettingDto.builder()
+            fcfsSettingList.set(fcfsSetting.getRound() - 1, FcfsSettingDto.builder()
                     .round(fcfsSetting.getRound())
                     .startTime(fcfsSetting.getStartTime())
                     .endTime(fcfsSetting.getEndTime())
@@ -74,56 +68,6 @@ public class FcfsSettingManager {
 
 
     }
-
-//    public void scheduleTask() {
-//        scheduledFuture = taskScheduler.schedule(this::updateFcfsSetting, new CronTrigger("59 59 23 * * *"));
-//    }
-
-    /**
-     * 1. 매일 23시 59분 59초에 스케줄러를 실행한다.
-     * 2. 현재 시간이 이벤트의 endTime 이후라면 다음 round에 해당하는 이벤트 속성으로 설정한다.
-     * 3. Redis에 저장된 선착순 이벤트 참여자 수를 DB에 저장하고 Redis에서 데이터를 삭제한다.
-     */
-//    @Transactional
-//    protected void updateFcfsSetting() {
-//        LocalDateTime now = LocalDateTime.now();
-//        if (now.isAfter(endTime)) {
-//            try {
-//                FcfsSetting fcfsSetting = fcfsSettingRepository.findByRound(round + 1)
-//                        .orElseThrow(() -> new IllegalStateException("Next FcfsSetting not found"));
-//
-//                this.round = fcfsSetting.getRound();
-//                this.startTime = fcfsSetting.getStartTime();
-//                this.endTime = fcfsSetting.getEndTime();
-//                this.winnerNum = fcfsSetting.getWinnerNum();
-//                this.isFcfsClosed = false;
-//
-//                log.info("FcfsSetting updated to round {}", round);
-//
-//                // TODO: 현재 날짜를 기준으로 하루 전 날짜로 방문자수, 추첨 및 선착순 참가자 수를 EventParticipation에 저장하는 로직 구현
-//                int participantCount = eventLockRedisUtil.getData(RedisLockPrefix.FCFS_LOCK_PREFIX.getPrefix() + round);
-//                EventParticipation eventParticipation = eventParticipationRepository.findSingleEventParticipation();
-//                eventParticipation.addFcfsParticipantCount(participantCount);
-//
-//                eventLockRedisUtil.deleteParticipantCount(RedisLockPrefix.FCFS_PARTICIPANT_COUNT_PREFIX.getPrefix() + round);
-//                eventLockRedisUtil.deleteParticipantIds(RedisLockPrefix.FCFS_LOCK_PREFIX.getPrefix() + (round - 1));
-//
-//            } catch (Exception e) {
-//                log.info("Updating FcfsSetting is final");
-//                stopScheduler();
-//            }
-//        }
-//    }
-
-    /**
-     * Schedular의 작업을 비활성화 시키는 메서드
-     */
-    public void stopScheduler() {
-        if (scheduledFuture != null) {
-            scheduledFuture.cancel(false);
-        }
-    }
-
 
     public void setFcfsTime(List<FcfsSetting> fcfsSettingList) {
         fcfsSettingList
@@ -138,6 +82,21 @@ public class FcfsSettingManager {
         fcfsSettingList.forEach((fcfsSettingDto) -> {
             fcfsSettingDto.setWinnerNum(fcfsWinnerNum);
         });
+    }
+
+    public int getRoundForScheduler(LocalDate localDate) {
+        for (FcfsSettingDto fcfsSettingDto : fcfsSettingList) {
+            if (fcfsSettingDto != null) {
+                LocalDate startDate = fcfsSettingDto.getStartTime().toLocalDate();
+                LocalDate dayAfterStartDate = startDate.plusDays(1);
+
+                // localDate가 startDate의 하루 다음날과 같은지 확인
+                if (localDate.equals(dayAfterStartDate)) {
+                    return fcfsSettingDto.getRound();
+                }
+            }
+        }
+        return -1;  // 해당하는 데이터가 없는 경우
     }
 
 

--- a/src/main/java/com/softeer/backend/fo_domain/mainpage/service/MainPageService.java
+++ b/src/main/java/com/softeer/backend/fo_domain/mainpage/service/MainPageService.java
@@ -3,10 +3,14 @@ package com.softeer.backend.fo_domain.mainpage.service;
 import com.softeer.backend.fo_domain.draw.service.DrawSettingManager;
 import com.softeer.backend.fo_domain.mainpage.dto.MainPageCarResponseDto;
 import com.softeer.backend.fo_domain.mainpage.dto.MainPageEventResponseDto;
+import com.softeer.backend.global.common.constant.RedisKeyPrefix;
 import com.softeer.backend.global.staticresources.util.StaticResourcesUtil;
+import com.softeer.backend.global.util.EventLockRedisUtil;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.Arrays;
 
@@ -15,10 +19,13 @@ import java.util.Arrays;
 public class MainPageService {
     private final DateTimeFormatter eventTimeFormatter = DateTimeFormatter.ofPattern("yyyy.MM.dd");
 
+    private final EventLockRedisUtil eventLockRedisUtil;
     private final StaticResourcesUtil staticResourcesUtil;
     private final DrawSettingManager drawSettingManager;
 
     public MainPageEventResponseDto getEventPage(){
+
+        setTotalVisitorsCount();
 
         MainPageEventResponseDto.EventInfo fcfsInfo = MainPageEventResponseDto.EventInfo.builder()
                 .title(staticResourcesUtil.getData("FCFS_TITLE"))
@@ -44,6 +51,17 @@ public class MainPageService {
                 .remainDrawCount(staticResourcesUtil.getData("REMAIN_DRAW_COUNT"))
                 .eventInfoList(Arrays.asList(fcfsInfo, drawInfo))
                 .build();
+
+    }
+
+    // 이벤트 기간이면 redis에 사이트 방문자 수 +1 하기
+    private void setTotalVisitorsCount(){
+
+        LocalDate now = LocalDate.now();
+
+        if (!now.isBefore(drawSettingManager.getStartDate()) && !now.isAfter(drawSettingManager.getEndDate())) {
+            eventLockRedisUtil.incrementData(RedisKeyPrefix.TOTAL_VISITORS_COUNT_PREFIX.getPrefix());
+        }
 
     }
 

--- a/src/main/java/com/softeer/backend/global/common/constant/RedisKeyPrefix.java
+++ b/src/main/java/com/softeer/backend/global/common/constant/RedisKeyPrefix.java
@@ -3,15 +3,17 @@ package com.softeer.backend.global.common.constant;
 import lombok.Getter;
 
 @Getter
-public enum RedisLockPrefix {
+public enum RedisKeyPrefix {
     FCFS_LOCK_PREFIX("LOCK:FCFS_WINNER_"),
     DRAW_LOCK_PREFIX("LOCK:DRAW_WINNER"),
     DRAW_TEMP_PREFIX("DRAW_TEMP_"),
-    FCFS_PARTICIPANT_COUNT_PREFIX("FCFS_PARTICIPANT_COUNT_");
+    FCFS_PARTICIPANT_COUNT_PREFIX("FCFS_PARTICIPANT_COUNT_"),
+    TOTAL_VISITORS_COUNT_PREFIX("TOTAL_VISITORS_COUNT_");
+
 
     private final String prefix;
 
-    RedisLockPrefix(String prefix) {
+    RedisKeyPrefix(String prefix) {
         this.prefix = prefix;
     }
 }

--- a/src/main/java/com/softeer/backend/global/config/schedular/SchedulerConfig.java
+++ b/src/main/java/com/softeer/backend/global/config/schedular/SchedulerConfig.java
@@ -5,12 +5,12 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
 
 @Configuration
-public class SchedularConfig {
+public class SchedulerConfig {
     @Bean
     public ThreadPoolTaskScheduler taskScheduler() {
         ThreadPoolTaskScheduler taskScheduler = new ThreadPoolTaskScheduler();
-        taskScheduler.setPoolSize(2);
-        taskScheduler.setThreadNamePrefix("EventScheduler-");
+        taskScheduler.setPoolSize(1);
+        taskScheduler.setThreadNamePrefix("DbInsertScheduler-");
         return taskScheduler;
     }
 }

--- a/src/main/java/com/softeer/backend/global/scheduler/DbInsertScheduler.java
+++ b/src/main/java/com/softeer/backend/global/scheduler/DbInsertScheduler.java
@@ -1,0 +1,110 @@
+package com.softeer.backend.global.scheduler;
+
+import com.softeer.backend.bo_domain.eventparticipation.domain.EventParticipation;
+import com.softeer.backend.bo_domain.eventparticipation.repository.EventParticipationRepository;
+import com.softeer.backend.fo_domain.draw.service.DrawSettingManager;
+import com.softeer.backend.fo_domain.fcfs.domain.Fcfs;
+import com.softeer.backend.fo_domain.fcfs.repository.FcfsRepository;
+import com.softeer.backend.fo_domain.fcfs.service.FcfsSettingManager;
+import com.softeer.backend.fo_domain.user.domain.User;
+import com.softeer.backend.fo_domain.user.exception.UserException;
+import com.softeer.backend.fo_domain.user.repository.UserRepository;
+import com.softeer.backend.global.common.code.status.ErrorStatus;
+import com.softeer.backend.global.common.constant.RedisKeyPrefix;
+import com.softeer.backend.global.util.EventLockRedisUtil;
+import jakarta.annotation.PostConstruct;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
+import org.springframework.scheduling.support.CronTrigger;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.util.Set;
+import java.util.concurrent.ScheduledFuture;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class DbInsertScheduler {
+
+    private final ThreadPoolTaskScheduler taskScheduler;
+    private final EventLockRedisUtil eventLockRedisUtil;
+    private final FcfsSettingManager fcfsSettingManager;
+    private final DrawSettingManager drawSettingManager;
+    private final EventParticipationRepository eventParticipationRepository;
+    private final UserRepository userRepository;
+    private final FcfsRepository fcfsRepository;
+
+
+    private ScheduledFuture<?> scheduledFuture;
+
+    @PostConstruct
+    public void init() {
+        scheduleTask();
+
+    }
+
+    public void scheduleTask() {
+        scheduledFuture = taskScheduler.schedule(this::updateFcfsSetting, new CronTrigger("0 0 1 * * *"));
+    }
+
+    @Transactional
+    protected void updateFcfsSetting() {
+        LocalDate now = LocalDate.now();
+        if (now.isBefore(drawSettingManager.getStartDate().plusDays(1)))
+            return;
+
+        if(now.isAfter(drawSettingManager.getEndDate().plusDays(1)))
+            stopScheduler();
+
+        int totalVisitorsCount = eventLockRedisUtil.getData(RedisKeyPrefix.TOTAL_VISITORS_COUNT_PREFIX.getPrefix());
+        eventLockRedisUtil.deleteData(RedisKeyPrefix.TOTAL_VISITORS_COUNT_PREFIX.getPrefix());
+
+        int fcfsParticipantCount = 0;
+        int drawParticipantCount = 0;
+
+        if(fcfsSettingManager.getRoundForScheduler(now)!=-1){
+            int round = fcfsSettingManager.getRoundForScheduler(now);
+
+            Set<Integer> participantIds = eventLockRedisUtil.getAllDataAsSet(RedisKeyPrefix.FCFS_LOCK_PREFIX.getPrefix() + round);
+            participantIds.forEach((userId) -> {
+                User user = userRepository.findById(userId)
+                        .orElseThrow(() -> {
+                            log.error("user not found in saveFcfsWinners method.");
+                            return new UserException(ErrorStatus._NOT_FOUND);
+                        });
+                Fcfs fcfs = Fcfs.builder()
+                        .user(user)
+                        .round(round)
+                        .build();
+                fcfsRepository.save(fcfs);
+            });
+
+            fcfsParticipantCount += eventLockRedisUtil.getData(RedisKeyPrefix.FCFS_PARTICIPANT_COUNT_PREFIX.getPrefix() + round);
+
+            eventLockRedisUtil.deleteData(RedisKeyPrefix.FCFS_PARTICIPANT_COUNT_PREFIX.getPrefix() + round);
+            eventLockRedisUtil.deleteData(RedisKeyPrefix.FCFS_LOCK_PREFIX.getPrefix() + round);
+        }
+
+        // TODO: drawParticipantCount에 추첨 이벤트 참가자 수 할당하기
+
+        eventParticipationRepository.save(EventParticipation.builder()
+                .visitorCount(totalVisitorsCount)
+                .fcfsParticipantCount(fcfsParticipantCount)
+                .drawParticipantCount(drawParticipantCount)
+                .eventDate(now.minusDays(1))
+                .build());
+
+    }
+
+    /**
+     * Schedular의 작업을 비활성화 시키는 메서드
+     */
+    public void stopScheduler() {
+        if (scheduledFuture != null) {
+            scheduledFuture.cancel(false);
+        }
+    }
+}

--- a/src/main/java/com/softeer/backend/global/util/EventLockRedisUtil.java
+++ b/src/main/java/com/softeer/backend/global/util/EventLockRedisUtil.java
@@ -38,11 +38,11 @@ public class EventLockRedisUtil {
 
     // key에 해당하는 데이터의 값을 1 더하는 메서드
     // 원자적으로 값을 증가시킨다.
-    public void incrementParticipantCount(String key) {
+    public void incrementData(String key) {
         getStringIntegerValueOperations().increment(key, 1);
     }
 
-    public void deleteParticipantCount(String key) {
+    public void deleteData(String key) {
         integerRedisTemplate.delete(key);
     }
 
@@ -62,9 +62,7 @@ public class EventLockRedisUtil {
         integerRedisTemplate.delete(key);
     }
 
-    public void deleteParticipantIds(String key) {
-        integerRedisTemplate.delete(key);
-    }
+
 
     private ValueOperations<String, Integer> getStringIntegerValueOperations() {
         return integerRedisTemplate.opsForValue();

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,8 +1,0 @@
-
-jwt:
-  bearer: ${JWT_BEARER:Bearer}
-  secret: ${JWT_SECRET_KEY}
-  access-expiration: ${JWT_ACCESS_EXPIRE:3600000} # 1?? (??: ms)
-  access-header: ${JWT_ACCESS_HEADER:Authorization} # Access Token ??
-  refresh-expiration: ${JWT_REFRESH_EXPIRE:86400000} # 1? (??: ms)
-  refresh-header: ${JWT_REFRESH_HEADER:Authorization-Refresh} # Refresh Token ??

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,0 +1,8 @@
+
+jwt:
+  bearer: ${JWT_BEARER:Bearer}
+  secret: ${JWT_SECRET_KEY}
+  access-expiration: ${JWT_ACCESS_EXPIRE:3600000} # 1?? (??: ms)
+  access-header: ${JWT_ACCESS_HEADER:Authorization} # Access Token ??
+  refresh-expiration: ${JWT_REFRESH_EXPIRE:86400000} # 1? (??: ms)
+  refresh-header: ${JWT_REFRESH_HEADER:Authorization-Refresh} # Refresh Token ??


### PR DESCRIPTION
## 요약

메인페이지 방문자 수 관리하는 기능 구현

## 작업 내용

- GET '/main/event' 요청을 할 경우, redis에 해당 날짜의 방문자 수를 추가하는 기능 구현
- 스케줄러로 1시가 되면 redis에 저장된 방문자 수를 DB에 저장하는 기능 구현

## 관련 이슈
<!--  관련된 이슈를 적어주세요.  -->

close #90 

## 첨부 자료 (선택사항)
