### PR TITLE
[Fix] 퀴즈 정답 문자열 변형 해결 및 swagger AccessToken에 자동으로 Bearer붙여주는 설정

### DIFF
--- a/src/main/java/com/softeer/backend/fo_domain/fcfs/service/FcfsSettingManager.java
+++ b/src/main/java/com/softeer/backend/fo_domain/fcfs/service/FcfsSettingManager.java
@@ -82,7 +82,7 @@ public class FcfsSettingManager {
             QuizDto quizDto = QuizDto.builder()
                     .hint(quiz.getHint())
                     .answerWord(quiz.getAnswerWord())
-                    .answerSentence(quiz.getAnswerSentence())
+                    .answerSentence(quiz.getAnswerSentence().replace("\\n", "\n"))
                     .startIndex(quiz.getStartIndex())
                     .endIndex(quiz.getEndIndex())
                     .build();

--- a/src/main/java/com/softeer/backend/global/config/docs/SwaggerConfig.java
+++ b/src/main/java/com/softeer/backend/global/config/docs/SwaggerConfig.java
@@ -58,6 +58,8 @@ public class SwaggerConfig {
     private SecurityScheme getJwtSecurityScheme() {
         return new SecurityScheme()
                 .type(SecurityScheme.Type.APIKEY)
+                .scheme("bearer")
+                .bearerFormat("JWT")
                 .in(SecurityScheme.In.HEADER)
                 .name(jwtProperties.getAccessHeader());
     }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,8 +1,0 @@
-
-jwt:
-  bearer: ${JWT_BEARER:Bearer}
-  secret: ${JWT_SECRET_KEY}
-  access-expiration: ${JWT_ACCESS_EXPIRE:3600000} # 1?? (??: ms)
-  access-header: ${JWT_ACCESS_HEADER:Authorization} # Access Token ??
-  refresh-expiration: ${JWT_REFRESH_EXPIRE:86400000} # 1? (??: ms)
-  refresh-header: ${JWT_REFRESH_HEADER:Authorization-Refresh} # Refresh Token ??

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,0 +1,8 @@
+
+jwt:
+  bearer: ${JWT_BEARER:Bearer}
+  secret: ${JWT_SECRET_KEY}
+  access-expiration: ${JWT_ACCESS_EXPIRE:3600000} # 1?? (??: ms)
+  access-header: ${JWT_ACCESS_HEADER:Authorization} # Access Token ??
+  refresh-expiration: ${JWT_REFRESH_EXPIRE:86400000} # 1? (??: ms)
+  refresh-header: ${JWT_REFRESH_HEADER:Authorization-Refresh} # Refresh Token ??


### PR DESCRIPTION
## 요약

퀴즈 정답 문자열 변형 해결 및 swagger AccessToken에 자동으로 Bearer붙여주는 설정

## 작업 내용

- 퀴즈 정답 문자열에서 '\\n'을 '\n'으로 바꿔주는 기능 구현
- swagger AccessToken에 자동으로 Bearer붙여주는 설정

## 관련 이슈
<!--  관련된 이슈를 적어주세요.  -->

close #122 

## 첨부 자료 (선택사항)
