### PR TITLE
기대평을 조회할 때 최신 댓글이 먼저 조회되지 않는 문제

### DIFF
--- a/src/main/java/com/softeer/backend/fo_domain/comment/repository/CommentRepository.java
+++ b/src/main/java/com/softeer/backend/fo_domain/comment/repository/CommentRepository.java
@@ -9,5 +9,5 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface CommentRepository extends JpaRepository<Comment, Integer> {
 
-    Page<Comment> findAllByIdLessThanOrderById(Integer id, Pageable pageable);
+    Page<Comment> findAllByIdLessThanOrderByIdDesc(Integer id, Pageable pageable);
 }

--- a/src/main/java/com/softeer/backend/fo_domain/comment/service/CommentService.java
+++ b/src/main/java/com/softeer/backend/fo_domain/comment/service/CommentService.java
@@ -11,6 +11,7 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.Collections;
 import java.util.List;
 
 @Service
@@ -29,8 +30,9 @@ public class CommentService {
     public CommentsResponseDto getComments(Integer userId, Integer cursor) {
 
         PageRequest pageRequest = PageRequest.of(0, SCROLL_SIZE + 1);
-        Page<Comment> page = commentRepository.findAllByIdLessThanOrderById(cursor, pageRequest);
+        Page<Comment> page = commentRepository.findAllByIdLessThanOrderByIdDesc(cursor, pageRequest);
         List<Comment> comments = page.getContent();
+        Collections.reverse(comments);
 
         ScrollPaginationUtil<Comment> commentCursor = ScrollPaginationUtil.of(comments, SCROLL_SIZE);
         return CommentsResponseDto.of(commentCursor, userId);

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,8 +1,0 @@
-
-jwt:
-  bearer: ${JWT_BEARER:Bearer}
-  secret: ${JWT_SECRET_KEY}
-  access-expiration: ${JWT_ACCESS_EXPIRE:3600000} # 1?? (??: ms)
-  access-header: ${JWT_ACCESS_HEADER:Authorization} # Access Token ??
-  refresh-expiration: ${JWT_REFRESH_EXPIRE:86400000} # 1? (??: ms)
-  refresh-header: ${JWT_REFRESH_HEADER:Authorization-Refresh} # Refresh Token ??

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,0 +1,8 @@
+
+jwt:
+  bearer: ${JWT_BEARER:Bearer}
+  secret: ${JWT_SECRET_KEY}
+  access-expiration: ${JWT_ACCESS_EXPIRE:3600000} # 1?? (??: ms)
+  access-header: ${JWT_ACCESS_HEADER:Authorization} # Access Token ??
+  refresh-expiration: ${JWT_REFRESH_EXPIRE:86400000} # 1? (??: ms)
+  refresh-header: ${JWT_REFRESH_HEADER:Authorization-Refresh} # Refresh Token ??


### PR DESCRIPTION
## 요약

기대평을 조회할 때 최신 댓글이 먼저 조회되지 않는 문제를 역순으로 정렬하여 해결

## 작업 내용

- 기대평을 가져올 때, 특정 comment id값보다 작으면서 제일 큰 id값들을 순서대로 30개 가져오도록 변경
- 가져온 comment entity들을 역순으로 정렬하여 반환

## 관련 이슈
<!--  관련된 이슈를 적어주세요.  -->

close #147 

## 첨부 자료 (선택사항)
