### PR TITLE
이벤트 설정정보를 스케줄러로 가져오는 기능 구현

### DIFF
--- a/src/main/java/com/softeer/backend/bo_domain/admin/dto/event/EventPageResponseDto.java
+++ b/src/main/java/com/softeer/backend/bo_domain/admin/dto/event/EventPageResponseDto.java
@@ -58,21 +58,21 @@ public class EventPageResponseDto {
 
     }
 
-    public static EventPageResponseDto of(FcfsSettingManager fcfsSettingManager, DrawSettingManager drawSettingManager) {
-        List<FcfsEvent> fcfsEventList = fcfsSettingManager.getFcfsSettingList().stream()
-                .map((fcfsSettingDto) ->
+    public static EventPageResponseDto of(List<FcfsSetting> fcfsSettingList, DrawSetting drawSetting) {
+        List<FcfsEvent> fcfsEventList = fcfsSettingList.stream()
+                .map((fcfsSetting) ->
                         EventPageResponseDto.FcfsEvent.builder()
-                                .round(fcfsSettingDto.getRound())
-                                .startTime(fcfsSettingDto.getStartTime())
-                                .endTime(fcfsSettingDto.getEndTime())
+                                .round(fcfsSetting.getRound())
+                                .startTime(fcfsSetting.getStartTime())
+                                .endTime(fcfsSetting.getEndTime())
                                 .build())
                 .toList();
 
         DrawEvent drawEvent = DrawEvent.builder()
-                .startDate(drawSettingManager.getStartDate())
-                .endDate(drawSettingManager.getEndDate())
-                .startTime(drawSettingManager.getStartTime())
-                .endTime(drawSettingManager.getEndTime())
+                .startDate(drawSetting.getStartDate())
+                .endDate(drawSetting.getEndDate())
+                .startTime(drawSetting.getStartTime())
+                .endTime(drawSetting.getEndTime())
                 .build();
 
         return EventPageResponseDto.builder()

--- a/src/main/java/com/softeer/backend/bo_domain/admin/dto/indicator/EventIndicatorResponseDto.java
+++ b/src/main/java/com/softeer/backend/bo_domain/admin/dto/indicator/EventIndicatorResponseDto.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.softeer.backend.bo_domain.admin.serializer.PercentageSerializer;
 import com.softeer.backend.bo_domain.admin.serializer.PhoneNumberSerializer;
 import com.softeer.backend.bo_domain.eventparticipation.domain.EventParticipation;
+import com.softeer.backend.fo_domain.draw.domain.DrawSetting;
 import com.softeer.backend.fo_domain.draw.service.DrawSettingManager;
 import lombok.*;
 
@@ -49,9 +50,9 @@ public class EventIndicatorResponseDto {
         private int visitorNum;
     }
 
-    public static EventIndicatorResponseDto of(List<EventParticipation> eventParticipationList, DrawSettingManager drawSettingManager) {
-        LocalDate startDate = drawSettingManager.getStartDate();
-        LocalDate endDate = drawSettingManager.getEndDate();
+    public static EventIndicatorResponseDto of(List<EventParticipation> eventParticipationList, DrawSetting drawSetting) {
+        LocalDate startDate = drawSetting.getStartDate();
+        LocalDate endDate = drawSetting.getEndDate();
 
         int totalVisitorCount = eventParticipationList.stream()
                 .mapToInt(EventParticipation::getVisitorCount)

--- a/src/main/java/com/softeer/backend/bo_domain/admin/dto/winner/WinnerPageResponseDto.java
+++ b/src/main/java/com/softeer/backend/bo_domain/admin/dto/winner/WinnerPageResponseDto.java
@@ -51,30 +51,30 @@ public class WinnerPageResponseDto {
         private double probability;
     }
 
-    public static WinnerPageResponseDto of(FcfsSettingManager fcfsSettingManager, DrawSettingManager drawSettingManager) {
-        List<FcfsEvent> fcfsEventList = fcfsSettingManager.getFcfsSettingList().stream()
-                .map((fcfsSettingDto) ->
+    public static WinnerPageResponseDto of(List<FcfsSetting> fcfsSettingList, DrawSetting drawSetting) {
+        List<FcfsEvent> fcfsEventList = fcfsSettingList.stream()
+                .map((fcfsSetting) ->
                         FcfsEvent.builder()
-                                .round(fcfsSettingDto.getRound())
-                                .eventDate(LocalDate.from(fcfsSettingDto.getStartTime()))
-                                .winnerNum(fcfsSettingDto.getWinnerNum())
+                                .round(fcfsSetting.getRound())
+                                .eventDate(LocalDate.from(fcfsSetting.getStartTime()))
+                                .winnerNum(fcfsSetting.getWinnerNum())
                                 .build())
                 .toList();
 
         DrawEvent drawEvent1 = DrawEvent.builder()
                 .rank(1)
-                .winnerNum(drawSettingManager.getWinnerNum1())
-                .probability(calculateWinningProbability(drawSettingManager.getWinnerNum1()))
+                .winnerNum(drawSetting.getWinnerNum1())
+                .probability(calculateWinningProbability(drawSetting.getWinnerNum1()))
                 .build();
         DrawEvent drawEvent2 = DrawEvent.builder()
                 .rank(2)
-                .winnerNum(drawSettingManager.getWinnerNum2())
-                .probability(calculateWinningProbability(drawSettingManager.getWinnerNum2()))
+                .winnerNum(drawSetting.getWinnerNum2())
+                .probability(calculateWinningProbability(drawSetting.getWinnerNum2()))
                 .build();
         DrawEvent drawEvent3 = DrawEvent.builder()
                 .rank(3)
-                .winnerNum(drawSettingManager.getWinnerNum3())
-                .probability(calculateWinningProbability(drawSettingManager.getWinnerNum3()))
+                .winnerNum(drawSetting.getWinnerNum3())
+                .probability(calculateWinningProbability(drawSetting.getWinnerNum3()))
                 .build();
 
         List<DrawEvent> drawEventList = Arrays.asList(drawEvent1, drawEvent2, drawEvent3);

--- a/src/main/java/com/softeer/backend/bo_domain/admin/service/EventPageService.java
+++ b/src/main/java/com/softeer/backend/bo_domain/admin/service/EventPageService.java
@@ -31,13 +31,10 @@ public class EventPageService {
     private final FcfsSettingRepository fcfsSettingRepository;
     private final DrawSettingRepository drawSettingRepository;
 
-    private final FcfsSettingManager fcfsSettingManager;
-    private final DrawSettingManager drawSettingManager;
-
     @Transactional(readOnly = true)
     public EventPageResponseDto getEventPage() {
 
-        return EventPageResponseDto.of(fcfsSettingManager, drawSettingManager);
+        return EventPageResponseDto.of(fcfsSettingRepository.findAll(), drawSettingRepository.findAll().get(0));
     }
 
     public void updateFcfsEventTime(FcfsEventTimeRequestDto fcfsEventTimeRequestDto) {
@@ -60,17 +57,15 @@ public class EventPageService {
         DrawSetting drawSetting = drawSettingRepository.findAll().get(0);
         updateDrawSetting(drawSetting, startDate, endDate);
 
-        fcfsSettingManager.setFcfsTime(fcfsSettingList);
-
     }
 
-    private void updateFcfsSetting(FcfsSetting setting, LocalDate date, LocalTime time) {
+    private void updateFcfsSetting(FcfsSetting fcfsSetting, LocalDate date, LocalTime time) {
 
         LocalDateTime newStartTime = LocalDateTime.of(date, time);
         LocalDateTime newEndTime = newStartTime.plusHours(2);
 
-        setting.setStartTime(newStartTime);
-        setting.setEndTime(newEndTime);
+        fcfsSetting.setStartTime(newStartTime);
+        fcfsSetting.setEndTime(newEndTime);
 
     }
 
@@ -83,7 +78,6 @@ public class EventPageService {
         drawSetting.setStartDate(startDateOfDraw);
         drawSetting.setEndDate(endDateOfDraw);
 
-        drawSettingManager.setDrawDate(drawSetting);
     }
 
     public void updateDrawEventTime(DrawEventTimeRequestDto drawEventTimeRequestDto) {
@@ -92,7 +86,6 @@ public class EventPageService {
         drawSetting.setStartTime(drawEventTimeRequestDto.getStartTime());
         drawSetting.setEndTime(drawEventTimeRequestDto.getEndTime());
 
-        drawSettingManager.setDrawTime(drawSetting);
     }
 
 

--- a/src/main/java/com/softeer/backend/bo_domain/admin/service/IndicatorPageService.java
+++ b/src/main/java/com/softeer/backend/bo_domain/admin/service/IndicatorPageService.java
@@ -17,16 +17,17 @@ import java.util.List;
 public class IndicatorPageService {
 
     private final EventParticipationRepository eventParticipationRepository;
-    private final DrawSettingManager drawSettingManager;
+    private final DrawSettingRepository drawSettingRepository;
 
     public EventIndicatorResponseDto getEventIndicator() {
 
+        DrawSetting drawSetting = drawSettingRepository.findAll().get(0);
 
         List<EventParticipation> eventParticipationList = eventParticipationRepository.findAllByEventDateBetween(
-                drawSettingManager.getStartDate(), drawSettingManager.getEndDate()
+                drawSetting.getStartDate(), drawSetting.getEndDate()
         );
 
-        return EventIndicatorResponseDto.of(eventParticipationList, drawSettingManager);
+        return EventIndicatorResponseDto.of(eventParticipationList, drawSetting);
     }
 
 }

--- a/src/main/java/com/softeer/backend/bo_domain/admin/service/WinnerPageService.java
+++ b/src/main/java/com/softeer/backend/bo_domain/admin/service/WinnerPageService.java
@@ -32,13 +32,11 @@ public class WinnerPageService {
     private final DrawRepository drawRepository;
     private final FcfsSettingRepository fcfsSettingRepository;
     private final DrawSettingRepository drawSettingRepository;
-    private final FcfsSettingManager fcfsSettingManager;
-    private final DrawSettingManager drawSettingManager;
 
     @Transactional(readOnly = true)
     public WinnerPageResponseDto getWinnerPage() {
 
-        return WinnerPageResponseDto.of(fcfsSettingManager, drawSettingManager);
+        return WinnerPageResponseDto.of(fcfsSettingRepository.findAll(), drawSettingRepository.findAll().get(0));
     }
 
     @Transactional(readOnly = true)
@@ -60,8 +58,6 @@ public class WinnerPageService {
         List<FcfsSetting> fcfsSettingList = fcfsSettingRepository.findAll();
 
         fcfsSettingList.forEach((fcfsSetting) -> fcfsSetting.setWinnerNum(fcfsWinnerUpdateRequestDto.getFcfsWinnerNum()));
-
-        fcfsSettingManager.setFcfsWinnerNum(fcfsWinnerUpdateRequestDto.getFcfsWinnerNum());
     }
 
     @Transactional
@@ -71,9 +67,5 @@ public class WinnerPageService {
         drawSetting.setWinnerNum1(drawWinnerUpdateRequestDto.getFirstWinnerNum());
         drawSetting.setWinnerNum2(drawWinnerUpdateRequestDto.getSecondWinnerNum());
         drawSetting.setWinnerNum3(drawWinnerUpdateRequestDto.getThirdWinnerNum());
-
-        drawSettingManager.setDrawWinnerNum(drawWinnerUpdateRequestDto.getFirstWinnerNum(),
-                drawWinnerUpdateRequestDto.getSecondWinnerNum(),
-                drawWinnerUpdateRequestDto.getThirdWinnerNum());
     }
 }

--- a/src/main/java/com/softeer/backend/fo_domain/draw/domain/Draw.java
+++ b/src/main/java/com/softeer/backend/fo_domain/draw/domain/Draw.java
@@ -8,6 +8,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.sql.Date;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 
 @Getter
@@ -30,5 +31,5 @@ public class Draw {
     private Integer rank;
 
     @Column(name = "winning_date")
-    private LocalDateTime winningDate;
+    private LocalDate winningDate;
 }

--- a/src/main/java/com/softeer/backend/fo_domain/draw/service/DrawSettingManager.java
+++ b/src/main/java/com/softeer/backend/fo_domain/draw/service/DrawSettingManager.java
@@ -53,19 +53,15 @@ public class DrawSettingManager {
         winnerNum3 = drawSetting.getWinnerNum3();
     }
 
-    public void setDrawDate(DrawSetting drawSetting) {
+    public void setDrawSetting(DrawSetting drawSetting) {
         this.startDate = drawSetting.getStartDate();
         this.endDate = drawSetting.getEndDate();
-    }
-
-    public void setDrawTime(DrawSetting drawSetting) {
         this.startTime = drawSetting.getStartTime();
         this.endTime = drawSetting.getEndTime();
+
+        this.winnerNum1 = drawSetting.getWinnerNum1();
+        this.winnerNum2 = drawSetting.getWinnerNum2();
+        this.winnerNum3 = drawSetting.getWinnerNum3();
     }
 
-    public void setDrawWinnerNum(int winnerNum1, int winnerNum2, int winnerNum3) {
-        this.winnerNum1 = winnerNum1;
-        this.winnerNum2 = winnerNum2;
-        this.winnerNum3 = winnerNum3;
-    }
 }

--- a/src/main/java/com/softeer/backend/fo_domain/fcfs/service/FcfsService.java
+++ b/src/main/java/com/softeer/backend/fo_domain/fcfs/service/FcfsService.java
@@ -40,6 +40,7 @@ public class FcfsService {
 
     private final FcfsSettingManager fcfsSettingManager;
     private final DrawSettingManager drawSettingManager;
+    private final QuizManager quizManager;
     private final FcfsRedisUtil fcfsRedisUtil;
     private final RandomCodeUtil randomCodeUtil;
     private final StaticResourceUtil staticResourceUtil;
@@ -47,7 +48,7 @@ public class FcfsService {
 
     public FcfsPageResponseDto getFcfsPage(int round) {
 
-        QuizDto quiz = fcfsSettingManager.getQuiz(round);
+        QuizDto quiz = quizManager.getQuiz(round);
         Map<String, String> textContentMap = staticResourceUtil.getTextContentMap();
 
         return FcfsPageResponseDto.builder()
@@ -62,7 +63,7 @@ public class FcfsService {
 
     public FcfsPageResponseDto getFcfsTutorialPage() {
 
-        QuizDto tutorialQuiz = fcfsSettingManager.getTutorialQuiz();
+        QuizDto tutorialQuiz = quizManager.getTutorialQuiz();
         Map<String, String> textContentMap = staticResourceUtil.getTextContentMap();
 
         return FcfsPageResponseDto.builder()
@@ -81,9 +82,9 @@ public class FcfsService {
      */
     public FcfsResultResponseDto handleFcfsEvent(int userId, int round, FcfsRequestDto fcfsRequestDto) {
 
-        if(!fcfsRequestDto.getAnswer().equals(fcfsSettingManager.getQuiz(round).getAnswerWord())) {
+        if(!fcfsRequestDto.getAnswer().equals(quizManager.getQuiz(round).getAnswerWord())) {
             log.error("fcfs quiz answer is not match, correct answer: {}, wrong anwer: {}",
-                    fcfsSettingManager.getQuiz(round).getAnswerWord(), fcfsRequestDto.getAnswer());
+                    quizManager.getQuiz(round).getAnswerWord(), fcfsRequestDto.getAnswer());
             throw new FcfsException(ErrorStatus._BAD_REQUEST);
         }
 

--- a/src/main/java/com/softeer/backend/fo_domain/fcfs/service/FcfsSettingManager.java
+++ b/src/main/java/com/softeer/backend/fo_domain/fcfs/service/FcfsSettingManager.java
@@ -36,13 +36,9 @@ public class FcfsSettingManager {
     private final QuizRepository quizRepository;
 
     private List<FcfsSettingDto> fcfsSettingList;
-    private QuizDto tutorialQuiz;
-    private List<QuizDto> quizList;
-
 
     @Setter
     private boolean isFcfsClosed = false;
-
 
     @PostConstruct
     public void init() {
@@ -73,41 +69,17 @@ public class FcfsSettingManager {
                     .winnerNum(fcfsSetting.getWinnerNum())
                     .build());
         });
-
-        List<Quiz> quizs = quizRepository.findAll(Sort.by(Sort.Direction.ASC, "id"));
-        quizList = new ArrayList<>();
-
-        quizs.forEach((quiz) -> {
-
-            QuizDto quizDto = QuizDto.builder()
-                    .hint(quiz.getHint())
-                    .answerWord(quiz.getAnswerWord())
-                    .answerSentence(quiz.getAnswerSentence().replace("\\n", "\n"))
-                    .startIndex(quiz.getStartIndex())
-                    .endIndex(quiz.getEndIndex())
-                    .build();
-
-            if(quiz.getHint().equals("튜토리얼"))
-                tutorialQuiz = quizDto;
-            else
-                quizList.add(quizDto);
-        });
-
-
     }
 
-    public void setFcfsTime(List<FcfsSetting> fcfsSettingList) {
-        fcfsSettingList
-                .forEach((fcfsSetting) -> {
-                    FcfsSettingDto fcfsSettingDto = this.fcfsSettingList.get(fcfsSetting.getRound()-1);
-                    fcfsSettingDto.setStartTime(fcfsSetting.getStartTime());
-                    fcfsSettingDto.setEndTime(fcfsSetting.getEndTime());
-                });
-    }
+    public void setFcfsSettingList(List<FcfsSetting> fcfsSettings){
 
-    public void setFcfsWinnerNum(int fcfsWinnerNum) {
-        fcfsSettingList.forEach((fcfsSettingDto) -> {
-            fcfsSettingDto.setWinnerNum(fcfsWinnerNum);
+        fcfsSettings.forEach((fcfsSetting) -> {
+            fcfsSettingList.set(fcfsSetting.getRound() - 1, FcfsSettingDto.builder()
+                    .round(fcfsSetting.getRound())
+                    .startTime(fcfsSetting.getStartTime())
+                    .endTime(fcfsSetting.getEndTime())
+                    .winnerNum(fcfsSetting.getWinnerNum())
+                    .build());
         });
     }
 
@@ -128,32 +100,6 @@ public class FcfsSettingManager {
 
     public int getFcfsWinnerNum(){
         return fcfsSettingList.get(0).getWinnerNum();
-    }
-
-    public String getHint(){
-
-        LocalDateTime now = LocalDateTime.now();
-
-        for (int i=0; i<fcfsSettingList.size(); i++) {
-
-            FcfsSettingDto fcfsSettingDto = fcfsSettingList.get(i);
-
-            if (fcfsSettingDto != null) {
-                LocalDateTime endTime = fcfsSettingDto.getEndTime();
-
-                // localDate가 startDate의 하루 다음날과 같은지 확인
-                if (endTime.isBefore(now)) {
-                    return quizList.get(i).getHint();
-                }
-            }
-        }
-
-        return null;
-    }
-
-    public QuizDto getQuiz(int round){
-        log.info("quiz: {}", quizList.get(round-1));
-        return quizList.get(round - 1);
     }
 
     public boolean isFcfsEntryAvailable(LocalDateTime now){

--- a/src/main/java/com/softeer/backend/fo_domain/fcfs/service/QuizManager.java
+++ b/src/main/java/com/softeer/backend/fo_domain/fcfs/service/QuizManager.java
@@ -1,0 +1,84 @@
+package com.softeer.backend.fo_domain.fcfs.service;
+
+import com.softeer.backend.fo_domain.fcfs.domain.FcfsSetting;
+import com.softeer.backend.fo_domain.fcfs.domain.Quiz;
+import com.softeer.backend.fo_domain.fcfs.dto.FcfsSettingDto;
+import com.softeer.backend.fo_domain.fcfs.dto.QuizDto;
+import com.softeer.backend.fo_domain.fcfs.repository.QuizRepository;
+import jakarta.annotation.PostConstruct;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Component;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+@Getter
+public class QuizManager {
+
+    private final FcfsSettingManager fcfsSettingManager;
+    private final QuizRepository quizRepository;
+
+    private QuizDto tutorialQuiz;
+    private List<QuizDto> quizList;
+
+    @PostConstruct
+    public void init() {
+        loadInitialData();
+    }
+
+    public void loadInitialData() {
+
+        List<Quiz> quizs = quizRepository.findAll(Sort.by(Sort.Direction.ASC, "id"));
+        quizList = new ArrayList<>();
+
+        quizs.forEach((quiz) -> {
+
+            QuizDto quizDto = QuizDto.builder()
+                    .hint(quiz.getHint())
+                    .answerWord(quiz.getAnswerWord())
+                    .answerSentence(quiz.getAnswerSentence().replace("\\n", "\n"))
+                    .startIndex(quiz.getStartIndex())
+                    .endIndex(quiz.getEndIndex())
+                    .build();
+
+            if(quiz.getHint().equals("튜토리얼"))
+                tutorialQuiz = quizDto;
+            else
+                quizList.add(quizDto);
+        });
+    }
+
+    public String getHint(){
+
+        LocalDateTime now = LocalDateTime.now();
+
+        for (int i=0; i<fcfsSettingManager.getFcfsSettingList().size(); i++) {
+
+            FcfsSettingDto fcfsSettingDto = fcfsSettingManager.getFcfsSettingList().get(i);
+
+            if (fcfsSettingDto != null) {
+                LocalDateTime endTime = fcfsSettingDto.getEndTime();
+
+                // localDate가 startDate의 하루 다음날과 같은지 확인
+                if (endTime.isBefore(now)) {
+                    return quizList.get(i).getHint();
+                }
+            }
+        }
+
+        return null;
+    }
+
+    public QuizDto getQuiz(int round){
+        log.info("quiz: {}", quizList.get(round-1));
+        return quizList.get(round - 1);
+    }
+}

--- a/src/main/java/com/softeer/backend/fo_domain/mainpage/service/MainPageService.java
+++ b/src/main/java/com/softeer/backend/fo_domain/mainpage/service/MainPageService.java
@@ -4,6 +4,7 @@ import com.softeer.backend.fo_domain.draw.repository.DrawRepository;
 import com.softeer.backend.fo_domain.draw.service.DrawSettingManager;
 import com.softeer.backend.fo_domain.fcfs.dto.FcfsSettingDto;
 import com.softeer.backend.fo_domain.fcfs.service.FcfsSettingManager;
+import com.softeer.backend.fo_domain.fcfs.service.QuizManager;
 import com.softeer.backend.fo_domain.mainpage.dto.MainPageCarResponseDto;
 import com.softeer.backend.fo_domain.mainpage.dto.MainPageEventInfoResponseDto;
 import com.softeer.backend.fo_domain.mainpage.dto.MainPageEventStaticResponseDto;
@@ -40,6 +41,7 @@ public class MainPageService {
     private final EventLockRedisUtil eventLockRedisUtil;
     private final FcfsSettingManager fcfsSettingManager;
     private final DrawSettingManager drawSettingManager;
+    private final QuizManager quizManager;
     private final DrawRepository drawRepository;
     private final StaticResourceUtil staticResourceUtil;
 
@@ -99,6 +101,7 @@ public class MainPageService {
                         textContentMap.get(StaticTextName.TOTAL_DRAW_WINNER.name()), decimalFormat.format(totalDrawWinner)))
                 .remainDrawCount(staticResourceUtil.format(
                         textContentMap.get(StaticTextName.REMAIN_DRAW_COUNT.name()), decimalFormat.format(remainDrawCount)))
+                .fcfsHint(quizManager.getHint())
                 .fcfsStartTime(fcfsSettingManager.getNextFcfsTime(LocalDateTime.now()))
                 .build();
     }

--- a/src/main/java/com/softeer/backend/fo_domain/user/controller/VerificationController.java
+++ b/src/main/java/com/softeer/backend/fo_domain/user/controller/VerificationController.java
@@ -3,6 +3,7 @@ package com.softeer.backend.fo_domain.user.controller;
 import com.softeer.backend.fo_domain.user.dto.verification.ConfirmCodeRequestDto;
 import com.softeer.backend.fo_domain.user.dto.verification.VerificationCodeRequestDto;
 import com.softeer.backend.fo_domain.user.dto.verification.VerificationCodeResponseDto;
+import com.softeer.backend.fo_domain.user.dto.verification.VerificationCodeTestResponseDto;
 import com.softeer.backend.fo_domain.user.service.VerificationService;
 import com.softeer.backend.global.common.response.ResponseDto;
 import jakarta.validation.Valid;
@@ -22,6 +23,15 @@ public class VerificationController {
     public ResponseDto<VerificationCodeResponseDto> sendVerificationCode(@Valid @RequestBody VerificationCodeRequestDto verificationCodeRequestDto) {
 
         VerificationCodeResponseDto response = verificationService.sendVerificationCode(verificationCodeRequestDto.getPhoneNumber());
+
+        return ResponseDto.onSuccess(response);
+
+    }
+
+    @PostMapping("/send/test")
+    public ResponseDto<VerificationCodeTestResponseDto> sendVerificationCodeTest(@Valid @RequestBody VerificationCodeRequestDto verificationCodeRequestDto) {
+
+        VerificationCodeTestResponseDto response = verificationService.sendVerificationCodeTest(verificationCodeRequestDto.getPhoneNumber());
 
         return ResponseDto.onSuccess(response);
 

--- a/src/main/java/com/softeer/backend/fo_domain/user/domain/User.java
+++ b/src/main/java/com/softeer/backend/fo_domain/user/domain/User.java
@@ -1,15 +1,13 @@
 package com.softeer.backend.fo_domain.user.domain;
 
 import jakarta.persistence.*;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 @Entity
 @NoArgsConstructor
 @AllArgsConstructor
 @Getter
+@Setter
 @Builder
 @Table(name = "users",
         indexes = {

--- a/src/main/java/com/softeer/backend/fo_domain/user/dto/verification/VerificationCodeTestResponseDto.java
+++ b/src/main/java/com/softeer/backend/fo_domain/user/dto/verification/VerificationCodeTestResponseDto.java
@@ -1,0 +1,14 @@
+package com.softeer.backend.fo_domain.user.dto.verification;
+
+import lombok.*;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor(access = AccessLevel.PUBLIC)
+@Builder
+@Getter
+public class VerificationCodeTestResponseDto {
+
+    private String verificationCode;
+
+    private int timeLimit;
+}

--- a/src/main/java/com/softeer/backend/fo_domain/user/service/LoginService.java
+++ b/src/main/java/com/softeer/backend/fo_domain/user/service/LoginService.java
@@ -88,6 +88,12 @@ public class LoginService {
         // 전화번호로 User 객체 조회
         else {
             User user = userRepository.findByPhoneNumber(loginRequestDto.getPhoneNumber());
+
+            if(!user.getName().equals(loginRequestDto.getName()))
+                throw new UserException(ErrorStatus._AUTH_USERNAME_NOT_MATCH);
+
+            user.setMarketingConsent(loginRequestDto.getMarketingConsent());
+
             userId = user.getId();
         }
 

--- a/src/main/java/com/softeer/backend/global/common/code/status/ErrorStatus.java
+++ b/src/main/java/com/softeer/backend/global/common/code/status/ErrorStatus.java
@@ -35,7 +35,8 @@ public enum ErrorStatus implements BaseErrorCode {
             "인증 코드의 인증 횟수를 초과하였습니다. 인증 코드 발급 API를 호출하세요."),
     _AUTH_CODE_ISSUE_LIMIT_EXCEEDED(HttpStatus.BAD_REQUEST, "A403",
             "인증 코드 발급 횟수를 초과하였습니다. 나중에 다시 시도하세요."),
-    _AUTH_CODE_NOT_VERIFIED(HttpStatus.BAD_REQUEST, "A404", "인증되지 않은 상태에서 로그인 할 수 없습니다.");
+    _AUTH_CODE_NOT_VERIFIED(HttpStatus.BAD_REQUEST, "A404", "인증되지 않은 상태에서 로그인 할 수 없습니다."),
+    _AUTH_USERNAME_NOT_MATCH(HttpStatus.BAD_REQUEST, "A405", "이미 등록된 번호입니다.");
 
     // 예외의 Http 상태값
     private final HttpStatus httpStatus;

--- a/src/main/java/com/softeer/backend/global/config/redis/RedisConfig.java
+++ b/src/main/java/com/softeer/backend/global/config/redis/RedisConfig.java
@@ -11,7 +11,6 @@ import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.serializer.GenericToStringSerializer;
-import org.springframework.data.redis.serializer.Jackson2JsonRedisSerializer;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
 
 /**

--- a/src/main/java/com/softeer/backend/global/config/schedular/SchedulerConfig.java
+++ b/src/main/java/com/softeer/backend/global/config/schedular/SchedulerConfig.java
@@ -9,8 +9,8 @@ public class SchedulerConfig {
     @Bean
     public ThreadPoolTaskScheduler taskScheduler() {
         ThreadPoolTaskScheduler taskScheduler = new ThreadPoolTaskScheduler();
-        taskScheduler.setPoolSize(1);
-        taskScheduler.setThreadNamePrefix("DbInsertScheduler-");
+        taskScheduler.setPoolSize(2);
+        taskScheduler.setThreadNamePrefix("Scheduler-");
         return taskScheduler;
     }
 }

--- a/src/main/java/com/softeer/backend/global/scheduler/DbInsertScheduler.java
+++ b/src/main/java/com/softeer/backend/global/scheduler/DbInsertScheduler.java
@@ -56,11 +56,11 @@ public class DbInsertScheduler {
     }
 
     public void scheduleTask() {
-        scheduledFuture = taskScheduler.schedule(this::updateFcfsSetting, new CronTrigger("0 0 1 * * *"));
+        scheduledFuture = taskScheduler.schedule(this::insertDate, new CronTrigger("0 0 2 * * *"));
     }
 
     @Transactional
-    protected void updateFcfsSetting() {
+    protected void insertDate() {
         LocalDate now = LocalDate.now();
         if (now.isBefore(drawSettingManager.getStartDate().plusDays(1)))
             return;
@@ -113,7 +113,7 @@ public class DbInsertScheduler {
             drawWinnerKey = RedisKeyPrefix.DRAW_WINNER_LIST_PREFIX.getPrefix() + ranking;
             Set<Integer> winnerSet = drawRedisUtil.getAllDataAsSet(drawWinnerKey);
 
-            LocalDateTime winningDate = LocalDateTime.now().minusHours(2); // 하루 전 날 오후 11시로 설정
+            LocalDate winningDate = LocalDate.now().minusDays(1);
 
             for (Integer userId : winnerSet) {
                 User user = userRepository.findById(userId).orElseThrow(

--- a/src/main/java/com/softeer/backend/global/scheduler/EventSettingScheduler.java
+++ b/src/main/java/com/softeer/backend/global/scheduler/EventSettingScheduler.java
@@ -1,0 +1,58 @@
+package com.softeer.backend.global.scheduler;
+
+import com.softeer.backend.fo_domain.draw.domain.DrawSetting;
+import com.softeer.backend.fo_domain.draw.repository.DrawSettingRepository;
+import com.softeer.backend.fo_domain.draw.service.DrawSettingManager;
+import com.softeer.backend.fo_domain.fcfs.domain.FcfsSetting;
+import com.softeer.backend.fo_domain.fcfs.repository.FcfsSettingRepository;
+import com.softeer.backend.fo_domain.fcfs.service.FcfsSettingManager;
+import jakarta.annotation.PostConstruct;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
+import org.springframework.scheduling.support.CronTrigger;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.concurrent.ScheduledFuture;
+
+@Component
+@RequiredArgsConstructor
+public class EventSettingScheduler {
+
+    private final ThreadPoolTaskScheduler taskScheduler;
+
+    private final FcfsSettingManager fcfsSettingManager;
+    private final DrawSettingManager drawSettingManager;
+    private final FcfsSettingRepository fcfsSettingRepository;
+    private final DrawSettingRepository drawSettingRepository;
+
+    private ScheduledFuture<?> scheduledFuture;
+
+    @PostConstruct
+    public void init() {
+        scheduleTask();
+
+    }
+
+    public void scheduleTask() {
+        scheduledFuture = taskScheduler.schedule(this::updateEventSetting, new CronTrigger("0 0 1 * * *"));
+    }
+
+    @Transactional(readOnly = true)
+    protected void updateEventSetting() {
+        LocalDateTime now = LocalDateTime.now();
+        if (now.isBefore(LocalDateTime.of(drawSettingManager.getStartDate(), drawSettingManager.getStartTime()))
+        || now.isAfter(LocalDateTime.of(drawSettingManager.getEndDate(), drawSettingManager.getEndTime()))){
+
+            List<FcfsSetting> fcfsSettings = fcfsSettingRepository.findAll();
+            DrawSetting drawSetting = drawSettingRepository.findAll().get(0);
+
+            fcfsSettingManager.setFcfsSettingList(fcfsSettings);
+            drawSettingManager.setDrawSetting(drawSetting);
+        }
+    }
+
+}

--- a/src/main/java/com/softeer/backend/global/staticresources/util/StaticResourceUtil.java
+++ b/src/main/java/com/softeer/backend/global/staticresources/util/StaticResourceUtil.java
@@ -24,7 +24,8 @@ public class StaticResourceUtil {
 
     public Map<String, String> getTextContentMap() {
         return textContentRepository.findAll().stream()
-                .collect(Collectors.toMap(TextContent::getTextName, TextContent::getContent));
+                .collect(Collectors.toMap(TextContent::getTextName,
+                        textContent -> textContent.getContent().replace("\\n", "\n")));
     }
 
     public Map<String, String> getS3ContentMap() {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,8 +1,0 @@
-
-jwt:
-  bearer: ${JWT_BEARER:Bearer}
-  secret: ${JWT_SECRET_KEY}
-  access-expiration: ${JWT_ACCESS_EXPIRE:3600000} # 1?? (??: ms)
-  access-header: ${JWT_ACCESS_HEADER:Authorization} # Access Token ??
-  refresh-expiration: ${JWT_REFRESH_EXPIRE:86400000} # 1? (??: ms)
-  refresh-header: ${JWT_REFRESH_HEADER:Authorization-Refresh} # Refresh Token ??

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,0 +1,8 @@
+
+jwt:
+  bearer: ${JWT_BEARER:Bearer}
+  secret: ${JWT_SECRET_KEY}
+  access-expiration: ${JWT_ACCESS_EXPIRE:3600000} # 1?? (??: ms)
+  access-header: ${JWT_ACCESS_HEADER:Authorization} # Access Token ??
+  refresh-expiration: ${JWT_REFRESH_EXPIRE:86400000} # 1? (??: ms)
+  refresh-header: ${JWT_REFRESH_HEADER:Authorization-Refresh} # Refresh Token ??


### PR DESCRIPTION
## 요약

이벤트 설정정보를 싱글톤으로 관리하면 어드민 기능으로 설정정보를 변경할 때, 동기화가 어려우므로
스케줄러로 특정 시간마다 설정정보를 DB에서 가져와 설정하도록 변경한다.

## 작업 내용

- 선착순 설정정보 동기화를 스케줄러로 구현
- 추첨 설정정보 동기화를 스케줄러로 구현
- 퀴즈 정보를 선착순 설정 매니저에서 분리하여 관리하도록 구현
- 유저 인증번호 전송 test용 api 구현

## 관련 이슈
<!--  관련된 이슈를 적어주세요.  -->

close #162 

## 첨부 자료 (선택사항)
